### PR TITLE
Rotation affordance: keyboard input + yellow edge-line HUD + easy-mode hints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,9 +14,13 @@ import { DioramaGrid } from './diorama/DioramaGrid'
 import { BezierCurveEditor } from './diorama/BezierCurveEditor'
 import { Controls } from './Controls'
 import { usePlanet } from './world/store'
+import { NEIGHBOR_IDX } from './world/rotation'
+import { hudUniforms } from './diorama/buildDiorama'
 
 if (import.meta.env.DEV && typeof window !== 'undefined') {
   ;(window as unknown as Record<string, unknown>).__planet = usePlanet
+  ;(window as unknown as Record<string, unknown>).__neighborIdx = NEIGHBOR_IDX
+  ;(window as unknown as Record<string, unknown>).__hud = hudUniforms
 }
 
 function Cursor() {

--- a/src/Controls.tsx
+++ b/src/Controls.tsx
@@ -21,6 +21,7 @@ export function Controls({
   const setShowRing = usePlanet(s => s.setShowRing)
   const setCommitThreshold = usePlanet(s => s.setCommitThreshold)
   const setAiEnabled = usePlanet(s => s.setAiEnabled)
+  const setEasyMode = usePlanet(s => s.setEasyMode)
 
   useControls({
     'View: Cube net': button(() => setDioramaPreview(dioramaPreview === 'grid' ? false : 'grid')),
@@ -38,6 +39,10 @@ export function Controls({
     'AI seed': {
       value: true,
       onChange: (v: boolean) => setAiEnabled(v),
+    },
+    'Easy mode (HUD hints)': {
+      value: false,
+      onChange: (v: boolean) => setEasyMode(v),
     },
     'Commit threshold (°)': {
       value: 6.5,

--- a/src/diorama/TileGrid.tsx
+++ b/src/diorama/TileGrid.tsx
@@ -15,11 +15,15 @@ import { buildDiorama, buildSphereTerrain, fresnelUniform, sliceRotUniforms, hud
 import { COLS, ROWS, CELL, cellFace, FACE_TO_BLOCK_TL } from './DioramaGrid'
 import { FACES, type FaceIndex } from '../world/faces'
 import { usePlanet } from '../world/store'
-import { AXIS_VEC, tileInSlice, type Axis } from '../world/rotation'
+import { AXIS_VEC, tileInSlice, NEIGHBOR_IDX, type Axis } from '../world/rotation'
 import { useHdri } from '../world/hdriStore'
 import type { Tile } from '../world/tile'
 
 const SLICE_ROT_MS = 380
+
+// Scratch buffer for the per-frame edge-mask recompute. Module-scoped so we
+// don't allocate 24 ints per frame. 24 slots, one per current tile position.
+const _atHomeScratch = new Uint8Array(24)
 
 function easeInOutCubic(t: number): number {
   return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2
@@ -656,9 +660,38 @@ export function TileGrid({ mode = 'split', bezier }: {
     // Ease HUD attract opacity toward its target. 1.0 while in attract mode
     // (fresh session, no moves yet); 0.0 once the player commits their first
     // rotation. ~1 s ease over the transition feels "aha, they got it."
-    const hudTarget = usePlanet.getState().hudAttractMode ? 1 : 0
+    const pState = usePlanet.getState()
+    const hudTarget = pState.hudAttractMode ? 1 : 0
     const HUD_EASE = 0.04  // per-frame lerp factor ≈ 1s at 60fps
     hudUniforms.uHudOpacity.value += (hudTarget - hudUniforms.uHudOpacity.value) * HUD_EASE
+    // Ease easy-mode colour weight toward current store value. Same ease so
+    // toggling feels smooth rather than snappy.
+    const easyTarget = pState.easyMode ? 1 : 0
+    hudUniforms.uHudEasyMode.value += (easyTarget - hudUniforms.uHudEasyMode.value) * HUD_EASE
+
+    // Per-edge correctness mask for the HUD's easy-mode coloring. 0 = both
+    // self and neighbor are at their home positions (green); 1 = either is
+    // misplaced (red). Computed every frame — 24 tiles × 4 edges = 96 cheap
+    // comparisons, no allocation.
+    {
+      const tiles = pState.tiles
+      const mask = hudUniforms.uHudTileEdgeMask.value as Float32Array
+      const atHome = _atHomeScratch
+      for (let i = 0; i < 24; i++) atHome[i] = 0
+      for (const t of tiles) {
+        const idx = t.face * 4 + t.v * 2 + t.u
+        const home = t.homeFace === t.face && t.homeU === t.u && t.homeV === t.v
+        atHome[idx] = home ? 1 : 0
+      }
+      for (let idx = 0; idx < 24; idx++) {
+        const selfHome = atHome[idx]
+        const base = idx * 4
+        for (let e = 0; e < 4; e++) {
+          const neighIdx = NEIGHBOR_IDX[base + e]
+          mask[base + e] = selfHome && atHome[neighIdx] ? 0 : 1
+        }
+      }
+    }
 
     diorama.update(clock.elapsedTime)
 

--- a/src/diorama/TileGrid.tsx
+++ b/src/diorama/TileGrid.tsx
@@ -11,7 +11,7 @@ import { useEffect, useMemo, useRef } from 'react'
 import * as THREE from 'three'
 import { useFrame, useThree } from '@react-three/fiber'
 import { useFBO } from '@react-three/drei'
-import { buildDiorama, buildSphereTerrain, fresnelUniform, sliceRotUniforms, HALF_W, HALF_H, type DioramaScene } from './buildDiorama'
+import { buildDiorama, buildSphereTerrain, fresnelUniform, sliceRotUniforms, hudUniforms, HALF_W, HALF_H, type DioramaScene } from './buildDiorama'
 import { COLS, ROWS, CELL, cellFace, FACE_TO_BLOCK_TL } from './DioramaGrid'
 import { FACES, type FaceIndex } from '../world/faces'
 import { usePlanet } from '../world/store'
@@ -652,6 +652,13 @@ export function TileGrid({ mode = 'split', bezier }: {
       if (m) applyIblKnobs(m)
     })
     if (terrainMeshRef.current) applyIblKnobs(terrainMeshRef.current.material)
+
+    // Ease HUD attract opacity toward its target. 1.0 while in attract mode
+    // (fresh session, no moves yet); 0.0 once the player commits their first
+    // rotation. ~1 s ease over the transition feels "aha, they got it."
+    const hudTarget = usePlanet.getState().hudAttractMode ? 1 : 0
+    const HUD_EASE = 0.04  // per-frame lerp factor ≈ 1s at 60fps
+    hudUniforms.uHudOpacity.value += (hudTarget - hudUniforms.uHudOpacity.value) * HUD_EASE
 
     diorama.update(clock.elapsedTime)
 

--- a/src/diorama/buildDiorama.ts
+++ b/src/diorama/buildDiorama.ts
@@ -326,16 +326,17 @@ function patchMaterialForTriplanar(material: THREE.Material, texture: THREE.Text
          float dotMask = 1.0 - smoothstep(r * 0.55, r, dotDist);
 
          // Easy-mode edge coloring (L3): sample the per-edge mask for this
-         // tile, pick whichever edge the fragment is nearest. In L2 the mask
-         // is all zeros → monochrome dots only.
+         // tile, pick whichever edge the fragment is nearest. Robust to
+         // float slop — compare edgeDistU vs edgeDistV explicitly.
          vec4 mask = uHudTileEdgeMask[tileIdx];
-         float maskVal = (uL > 0.0 && edgeDist == 0.5 - abs(uL))
-           ? mask.x
-           : (uL < 0.0 && edgeDist == 0.5 - abs(uL))
-             ? mask.y
-             : (vL > 0.0 && edgeDist == 0.5 - abs(vL))
-               ? mask.z
-               : mask.w;
+         float edgeDistU = 0.5 - abs(uL);
+         float edgeDistV = 0.5 - abs(vL);
+         float maskVal;
+         if (edgeDistU < edgeDistV) {
+           maskVal = (uL > 0.0) ? mask.x : mask.y;
+         } else {
+           maskVal = (vL > 0.0) ? mask.z : mask.w;
+         }
          vec3 hudColMono = vec3(0.92, 0.95, 1.0);
          vec3 hudColGood = vec3(0.55, 0.95, 0.55);
          vec3 hudColBad  = vec3(0.95, 0.55, 0.45);

--- a/src/diorama/buildDiorama.ts
+++ b/src/diorama/buildDiorama.ts
@@ -273,78 +273,95 @@ function patchMaterialForTriplanar(material: THREE.Material, texture: THREE.Text
        vec4 triCol = triX * triW.x + triY * triW.y + triZ * triW.z;
        diffuseColor *= triCol;
 
-       // ── HUD overlay ────────────────────────────────────────────
-       // 6×6 dot grid per tile, size boosted at tile edges and by
-       // cursor proximity. Global uHudOpacity drives attract mode
-       // (whole planet covered at t=0, fades to 0 after first commit).
+       // ── HUD overlay: tile edge lines ───────────────────────────
+       // Two line thicknesses distinguish the two kinds of tile edge on a
+       // 2×2 puzzle:
+       //   • THIN — cube face-boundary edges between tiles on adjacent
+       //     faces. These tiles belong to the SAME corner cubie and always
+       //     rotate together; the edge is a within-piece seam, cosmetic.
+       //   • THICK — face-internal mid-face seams. These cut between two
+       //     different cubies on the same face; any axis rotation shears
+       //     across this seam. These are the slice boundaries — the
+       //     "rotatable tile group" edges the player cares about.
+       // Global uHudOpacity drives attract mode (whole planet lit at t=0);
+       // cursor proximity gives a localized reveal after attract fades.
        {
-         // Re-derive face basis for hudWorldP (tile's visible cube cell).
+         // Re-derive face basis for hudWorldP (the tile's visible cube cell).
          vec3 absP = abs(hudWorldP);
          vec3 fRight, fUp;
-         int hFace;
          if (absP.x >= absP.y && absP.x >= absP.z) {
-           if (hudWorldP.x > 0.0) { hFace = 0; fRight = vec3(0.0, 0.0,-1.0); fUp = vec3(0.0, 1.0, 0.0); }
-           else                    { hFace = 1; fRight = vec3(0.0, 0.0, 1.0); fUp = vec3(0.0, 1.0, 0.0); }
+           if (hudWorldP.x > 0.0) { fRight = vec3(0.0, 0.0,-1.0); fUp = vec3(0.0, 1.0, 0.0); }
+           else                    { fRight = vec3(0.0, 0.0, 1.0); fUp = vec3(0.0, 1.0, 0.0); }
          } else if (absP.y >= absP.z) {
-           if (hudWorldP.y > 0.0) { hFace = 2; fRight = vec3(1.0, 0.0, 0.0); fUp = vec3(0.0, 0.0,-1.0); }
-           else                    { hFace = 3; fRight = vec3(1.0, 0.0, 0.0); fUp = vec3(0.0, 0.0, 1.0); }
+           if (hudWorldP.y > 0.0) { fRight = vec3(1.0, 0.0, 0.0); fUp = vec3(0.0, 0.0,-1.0); }
+           else                    { fRight = vec3(1.0, 0.0, 0.0); fUp = vec3(0.0, 0.0, 1.0); }
          } else {
-           if (hudWorldP.z > 0.0) { hFace = 4; fRight = vec3(1.0, 0.0, 0.0); fUp = vec3(0.0, 1.0, 0.0); }
-           else                    { hFace = 5; fRight = vec3(-1.0,0.0, 0.0); fUp = vec3(0.0, 1.0, 0.0); }
+           if (hudWorldP.z > 0.0) { fRight = vec3(1.0, 0.0, 0.0); fUp = vec3(0.0, 1.0, 0.0); }
+           else                    { fRight = vec3(-1.0,0.0, 0.0); fUp = vec3(0.0, 1.0, 0.0); }
          }
          float dotR = dot(hudWorldP, fRight);
          float dotU = dot(hudWorldP, fUp);
          int tU = (dotR > 0.0) ? 1 : 0;
          int tV = (dotU > 0.0) ? 0 : 1;
-         // Tile-local UV, each ∈ [-0.5, 0.5]. Uses the CELL=1 convention.
+         // Tile-local UV ∈ [-0.5, 0.5] along face.right and face.up.
          float uL = dotR - (float(tU) - 0.5);
          float vL = dotU - (0.5 - float(tV));
 
-         // 6×6 dot grid per tile.
-         const float N_DOTS = 6.0;
-         float gU = floor(uL * N_DOTS + 0.5) / N_DOTS;
-         float gV = floor(vL * N_DOTS + 0.5) / N_DOTS;
-         float dotDist = length(vec2(uL - gU, vL - gV));
-
-         // Edge bias — dots near tile edges grow larger so boundaries emerge.
-         float edgeDist = min(0.5 - abs(uL), 0.5 - abs(vL));
-         float edgeBias = 1.0 - smoothstep(0.0, 0.15, edgeDist);
-
-         // Cursor proximity in world space (pre-slice-unwind cursor ↔
-         // pre-slice-unwind fragment position; use vTriWorldPos for the
-         // fragment so the cursor region doesn't shift mid-rotation).
-         float cd = distance(vTriWorldPos, uHudCursor);
-         float cursorW = uHudCursorActive * exp(-(cd*cd) / (uHudHoverRadius*uHudHoverRadius));
-
-         // Reveal = max(attract opacity, cursor proximity weight).
-         float reveal = max(uHudOpacity, cursorW);
-
-         // Dot radius scales with reveal and edge bias.
-         float baseR = 0.018;
-         float edgeR = 0.050;
-         float r = mix(baseR, edgeR, edgeBias) * reveal;
-         float dotMask = 1.0 - smoothstep(r * 0.55, r, dotDist);
-
-         // Easy-mode edge coloring (L3): sample the per-edge mask for this
-         // tile, pick whichever edge the fragment is nearest. Robust to
-         // float slop — compare edgeDistU vs edgeDistV explicitly.
-         vec4 mask = uHudTileEdgeMask[tileIdx];
          float edgeDistU = 0.5 - abs(uL);
          float edgeDistV = 0.5 - abs(vL);
+         float edgeDist;
+         bool internalEdge;
+         if (edgeDistU < edgeDistV) {
+           edgeDist = edgeDistU;
+           // +right edge (uL>0) is internal iff tU==0 (neighbor u=1 same face);
+           // -right edge (uL<0) is internal iff tU==1.
+           internalEdge = (uL > 0.0) ? (tU == 0) : (tU == 1);
+         } else {
+           edgeDist = edgeDistV;
+           // +up edge (vL>0) is internal iff tV==1 (neighbor v=0 same face);
+           // -up edge (vL<0) is internal iff tV==0.
+           internalEdge = (vL > 0.0) ? (tV == 1) : (tV == 0);
+         }
+
+         // Line half-widths in tile-local units. Face-boundary lines are
+         // rendered from BOTH adjacent tiles (each draws its half), so the
+         // per-side width is roughly half the visible stroke.
+         float thinHW  = 0.012;
+         float thickHW = 0.028;
+         float hw = internalEdge ? thickHW : thinHW;
+
+         // Suppress at 3-face cube corners: fragments near the corner of a
+         // face (both edgeDistU and edgeDistV small) classify ambiguously
+         // because the max-abs-component face picker flickers between three
+         // candidate faces → visible speckle. Fade the line out where the
+         // "non-nearest" edge distance is also small.
+         float otherEdgeDist = (edgeDistU < edgeDistV) ? edgeDistV : edgeDistU;
+         float cornerFade = smoothstep(0.015, 0.06, otherEdgeDist);
+
+         // Cursor proximity in world space — vTriWorldPos (pre-slice-unwind)
+         // so the revealed region doesn't shift as a slice animates.
+         float cd = distance(vTriWorldPos, uHudCursor);
+         float cursorW = uHudCursorActive * exp(-(cd*cd) / (uHudHoverRadius*uHudHoverRadius));
+         float reveal = max(uHudOpacity, cursorW);
+
+         // Line alpha — soft inner edge so the stroke reads as an aliased line.
+         float lineAlpha = (1.0 - smoothstep(hw * 0.55, hw, edgeDist)) * reveal * cornerFade;
+
+         // Easy-mode tint (L3): sample the per-edge mask to tint the line
+         // green where both tiles are at home across this edge, red where not.
+         // Off in L3-disabled mode (uHudEasyMode eases to 0) → pure yellow.
+         vec4 mask = uHudTileEdgeMask[tileIdx];
          float maskVal;
          if (edgeDistU < edgeDistV) {
            maskVal = (uL > 0.0) ? mask.x : mask.y;
          } else {
            maskVal = (vL > 0.0) ? mask.z : mask.w;
          }
-         vec3 hudColMono = vec3(0.92, 0.95, 1.0);
-         vec3 hudColGood = vec3(0.55, 0.95, 0.55);
-         vec3 hudColBad  = vec3(0.95, 0.55, 0.45);
-         vec3 hudColEasy = mix(hudColGood, hudColBad, maskVal);
-         vec3 hudCol = mix(hudColMono, hudColEasy, uHudEasyMode * edgeBias);
+         vec3 yellow = vec3(1.00, 0.88, 0.25);
+         vec3 easyCol = mix(vec3(0.50, 0.95, 0.45), vec3(0.98, 0.45, 0.35), maskVal);
+         vec3 lineColor = mix(yellow, easyCol, uHudEasyMode);
 
-         float alpha = dotMask * reveal * 0.6;
-         diffuseColor.rgb = mix(diffuseColor.rgb, hudCol, alpha);
+         diffuseColor.rgb = mix(diffuseColor.rgb, lineColor, lineAlpha);
        }`,
     )
   }

--- a/src/diorama/buildDiorama.ts
+++ b/src/diorama/buildDiorama.ts
@@ -71,6 +71,30 @@ export const sliceRotUniforms = {
   uTileOriInv:  { value: _oriInvFlat },
 }
 
+/** Polka-dot HUD overlay uniforms, rendered by the global terrain's triplanar
+ *  fragment shader on top of the grass.
+ *
+ *  - uHudOpacity: global attract fade. 1.0 at t=0 (entire planet shows dots),
+ *    animated to 0.0 after first player commit — then only cursor reveals.
+ *  - uHudCursor: world-space cursor position, published by Interaction.tsx
+ *    on raycast hits.
+ *  - uHudCursorActive: 1.0 when cursor is on planet, 0.0 otherwise.
+ *  - uHudHoverRadius: world-space sigma of the gaussian cursor-proximity
+ *    falloff. 0.35 ≈ one-third of a cube face.
+ *  - uHudTileEdgeMask[96]: per-edge mask for L3 easy-mode correctness colors.
+ *    Layout: tileIdx * 4 + edgeIdx, where edge order is +right / -right /
+ *    +up / -up in face-local coords. 0 = correct neighbor, 1 = wrong.
+ *    All zeros in L2 (no-op); L3 wires it. */
+const _hudEdgeMaskFlat = new Float32Array(TILE_COUNT * 4)  // all zeros
+export const hudUniforms = {
+  uHudOpacity:       { value: 1.0 },
+  uHudCursor:        { value: new THREE.Vector3(0, 0, 0) },
+  uHudCursorActive:  { value: 0.0 },
+  uHudHoverRadius:   { value: 0.35 },
+  uHudTileEdgeMask:  { value: _hudEdgeMaskFlat },
+  uHudEasyMode:      { value: 0.0 },   // 0 = monochrome dots, 1 = green/red
+}
+
 /** Compose-safe fragment-shader patch that scales the indirect-specular
  *  radiance by uFresnelScale. Preserves any existing onBeforeCompile so
  *  it stacks with TileGrid's sphere-projection vertex patch.
@@ -133,6 +157,13 @@ function patchMaterialForTriplanar(material: THREE.Material, texture: THREE.Text
     shader.uniforms.uSliceSign = sliceRotUniforms.uSliceSign
     shader.uniforms.uSliceActive = sliceRotUniforms.uSliceActive
     shader.uniforms.uTileOriInv = sliceRotUniforms.uTileOriInv
+    // HUD overlay (dot pattern + cursor reveal + correctness colors)
+    shader.uniforms.uHudOpacity = hudUniforms.uHudOpacity
+    shader.uniforms.uHudCursor = hudUniforms.uHudCursor
+    shader.uniforms.uHudCursorActive = hudUniforms.uHudCursorActive
+    shader.uniforms.uHudHoverRadius = hudUniforms.uHudHoverRadius
+    shader.uniforms.uHudTileEdgeMask = hudUniforms.uHudTileEdgeMask
+    shader.uniforms.uHudEasyMode = hudUniforms.uHudEasyMode
 
     // Vertex: forward world-space position + normal to fragment.
     shader.vertexShader = shader.vertexShader.replace(
@@ -161,6 +192,12 @@ function patchMaterialForTriplanar(material: THREE.Material, texture: THREE.Text
        uniform float uSliceSign;
        uniform float uSliceActive;
        uniform vec4  uTileOriInv[24];
+       uniform float uHudOpacity;
+       uniform vec3  uHudCursor;
+       uniform float uHudCursorActive;
+       uniform float uHudHoverRadius;
+       uniform vec4  uHudTileEdgeMask[24];   // xyzw = +right, -right, +up, -up edge flags
+       uniform float uHudEasyMode;
        varying vec3 vTriWorldPos;
        varying vec3 vTriWorldNormal;
        vec3 rotateAxisAngle(vec3 p, vec3 axis, float ang) {
@@ -219,6 +256,11 @@ function patchMaterialForTriplanar(material: THREE.Material, texture: THREE.Text
          }
        }
        int tileIdx = computeTileIdx(worldP);
+       // Save post-slice-unwind, pre-orientation-unwind worldP for HUD.
+       // HUD dots anchor to the visible TILE's local frame (post-slice)
+       // but not to the tile's solved-state orientation (pre-ori) — this
+       // way dots sit on the tile as it rotates, same as the grass texture.
+       vec3 hudWorldP = worldP;
        vec4 oriInv = uTileOriInv[tileIdx];
        worldP = applyQuat(oriInv, worldP);
        worldN = applyQuat(oriInv, worldN);
@@ -229,7 +271,80 @@ function patchMaterialForTriplanar(material: THREE.Material, texture: THREE.Text
        vec4 triY = texture2D(uTriplanarMap, p.xz);
        vec4 triZ = texture2D(uTriplanarMap, p.xy);
        vec4 triCol = triX * triW.x + triY * triW.y + triZ * triW.z;
-       diffuseColor *= triCol;`,
+       diffuseColor *= triCol;
+
+       // ── HUD overlay ────────────────────────────────────────────
+       // 6×6 dot grid per tile, size boosted at tile edges and by
+       // cursor proximity. Global uHudOpacity drives attract mode
+       // (whole planet covered at t=0, fades to 0 after first commit).
+       {
+         // Re-derive face basis for hudWorldP (tile's visible cube cell).
+         vec3 absP = abs(hudWorldP);
+         vec3 fRight, fUp;
+         int hFace;
+         if (absP.x >= absP.y && absP.x >= absP.z) {
+           if (hudWorldP.x > 0.0) { hFace = 0; fRight = vec3(0.0, 0.0,-1.0); fUp = vec3(0.0, 1.0, 0.0); }
+           else                    { hFace = 1; fRight = vec3(0.0, 0.0, 1.0); fUp = vec3(0.0, 1.0, 0.0); }
+         } else if (absP.y >= absP.z) {
+           if (hudWorldP.y > 0.0) { hFace = 2; fRight = vec3(1.0, 0.0, 0.0); fUp = vec3(0.0, 0.0,-1.0); }
+           else                    { hFace = 3; fRight = vec3(1.0, 0.0, 0.0); fUp = vec3(0.0, 0.0, 1.0); }
+         } else {
+           if (hudWorldP.z > 0.0) { hFace = 4; fRight = vec3(1.0, 0.0, 0.0); fUp = vec3(0.0, 1.0, 0.0); }
+           else                    { hFace = 5; fRight = vec3(-1.0,0.0, 0.0); fUp = vec3(0.0, 1.0, 0.0); }
+         }
+         float dotR = dot(hudWorldP, fRight);
+         float dotU = dot(hudWorldP, fUp);
+         int tU = (dotR > 0.0) ? 1 : 0;
+         int tV = (dotU > 0.0) ? 0 : 1;
+         // Tile-local UV, each ∈ [-0.5, 0.5]. Uses the CELL=1 convention.
+         float uL = dotR - (float(tU) - 0.5);
+         float vL = dotU - (0.5 - float(tV));
+
+         // 6×6 dot grid per tile.
+         const float N_DOTS = 6.0;
+         float gU = floor(uL * N_DOTS + 0.5) / N_DOTS;
+         float gV = floor(vL * N_DOTS + 0.5) / N_DOTS;
+         float dotDist = length(vec2(uL - gU, vL - gV));
+
+         // Edge bias — dots near tile edges grow larger so boundaries emerge.
+         float edgeDist = min(0.5 - abs(uL), 0.5 - abs(vL));
+         float edgeBias = 1.0 - smoothstep(0.0, 0.15, edgeDist);
+
+         // Cursor proximity in world space (pre-slice-unwind cursor ↔
+         // pre-slice-unwind fragment position; use vTriWorldPos for the
+         // fragment so the cursor region doesn't shift mid-rotation).
+         float cd = distance(vTriWorldPos, uHudCursor);
+         float cursorW = uHudCursorActive * exp(-(cd*cd) / (uHudHoverRadius*uHudHoverRadius));
+
+         // Reveal = max(attract opacity, cursor proximity weight).
+         float reveal = max(uHudOpacity, cursorW);
+
+         // Dot radius scales with reveal and edge bias.
+         float baseR = 0.018;
+         float edgeR = 0.050;
+         float r = mix(baseR, edgeR, edgeBias) * reveal;
+         float dotMask = 1.0 - smoothstep(r * 0.55, r, dotDist);
+
+         // Easy-mode edge coloring (L3): sample the per-edge mask for this
+         // tile, pick whichever edge the fragment is nearest. In L2 the mask
+         // is all zeros → monochrome dots only.
+         vec4 mask = uHudTileEdgeMask[tileIdx];
+         float maskVal = (uL > 0.0 && edgeDist == 0.5 - abs(uL))
+           ? mask.x
+           : (uL < 0.0 && edgeDist == 0.5 - abs(uL))
+             ? mask.y
+             : (vL > 0.0 && edgeDist == 0.5 - abs(vL))
+               ? mask.z
+               : mask.w;
+         vec3 hudColMono = vec3(0.92, 0.95, 1.0);
+         vec3 hudColGood = vec3(0.55, 0.95, 0.55);
+         vec3 hudColBad  = vec3(0.95, 0.55, 0.45);
+         vec3 hudColEasy = mix(hudColGood, hudColBad, maskVal);
+         vec3 hudCol = mix(hudColMono, hudColEasy, uHudEasyMode * edgeBias);
+
+         float alpha = dotMask * reveal * 0.6;
+         diffuseColor.rgb = mix(diffuseColor.rgb, hudCol, alpha);
+       }`,
     )
   }
   material.customProgramCacheKey = () => (prevKey?.call(material) ?? '') + '|triplanar'

--- a/src/world/Interaction.tsx
+++ b/src/world/Interaction.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef } from 'react'
 import { useThree } from '@react-three/fiber'
 import * as THREE from 'three'
 import { usePlanet } from './store'
-import type { Axis } from './rotation'
+import { centroidToFaceUV, tileCentroid, type Axis, type Direction, type Move } from './rotation'
+import { FACES, type FaceDef, type FaceIndex } from './faces'
 
 // Pointer input lives here because both onPlanet tracking and drag-axis
 // resolution need the live camera for raycasting.
@@ -66,9 +67,69 @@ type PendingDrag =
       tangent: THREE.Vector2 // unit, in screen pixels
     }
 
+/** Map a sphere hit point to the (face, u, v) of the tile it lies in.
+ *  The hit is on the unit sphere; project onto the cube by dividing through
+ *  the max-abs component, then use centroidToFaceUV to pick the tile's cell.
+ *  Returns null for degenerate (origin) inputs. */
+function sphereHitToTile(hit: THREE.Vector3): { face: FaceIndex; u: number; v: number } | null {
+  const ax = Math.abs(hit.x), ay = Math.abs(hit.y), az = Math.abs(hit.z)
+  const m = Math.max(ax, ay, az)
+  if (m < 1e-6) return null
+  const cube = new THREE.Vector3(hit.x / m, hit.y / m, hit.z / m)
+  return centroidToFaceUV(cube)
+}
+
+/** Given a key + hovered face-local axes + tile centroid, derive the (axis,
+ *  slice, dir) Move. The 6 keys map to the 3 face-local axes × 2 directions:
+ *    Q/E  → rotate around face.normal (Q = CCW looking AT the face, E = CW)
+ *    W/S  → rotate around face.right  (W = tilt top away, S = tilt top toward)
+ *    A/D  → rotate around face.up     (A = left, D = right)
+ *  Slice is forced by the tile's world-axis component — there's only one
+ *  slice containing the hovered tile along each world axis. */
+function moveFromKey(key: string, face: FaceDef, tileUV: { u: number; v: number }): Move | null {
+  const centroid = tileCentroid(face.index, tileUV.u, tileUV.v)
+  const resolve = (dir: THREE.Vector3): { axis: Axis; worldSign: 1 | -1 } => {
+    const ax = Math.abs(dir.x), ay = Math.abs(dir.y), az = Math.abs(dir.z)
+    let axis: Axis
+    if (ax > 0.5) axis = 'x'
+    else if (ay > 0.5) axis = 'y'
+    else axis = 'z'
+    const worldSign = (dir[axis] > 0 ? 1 : -1) as 1 | -1
+    return { axis, worldSign }
+  }
+  const sliceOf = (axis: Axis): number => (centroid[axis] > 0 ? 1 : 0)
+
+  switch (key) {
+    case 'q':
+    case 'e': {
+      const { axis, worldSign } = resolve(face.normal)
+      // Q = CCW from viewer → dir = -worldSign; E = CW → dir = +worldSign.
+      const base = key === 'q' ? -1 : 1
+      return { axis, slice: sliceOf(axis), dir: (base * worldSign) as Direction }
+    }
+    case 'w':
+    case 's': {
+      const { axis, worldSign } = resolve(face.right)
+      // W tilts the face's top away from viewer; equivalent to rotating the
+      // slice +90° around face.right (right-hand rule: up → normal).
+      const base = key === 'w' ? 1 : -1
+      return { axis, slice: sliceOf(axis), dir: (base * worldSign) as Direction }
+    }
+    case 'a':
+    case 'd': {
+      const { axis, worldSign } = resolve(face.up)
+      // D rotates the face's right edge "down" (right-hand rule: normal → right).
+      const base = key === 'd' ? 1 : -1
+      return { axis, slice: sliceOf(axis), dir: (base * worldSign) as Direction }
+    }
+  }
+  return null
+}
+
 export function Interaction() {
   const { camera, gl, size } = useThree()
   const setOnPlanet = usePlanet(s => s.setOnPlanet)
+  const setHoveredTile = usePlanet(s => s.setHoveredTile)
   const beginDragAt = usePlanet(s => s.beginDragAt)
   const updateDrag = usePlanet(s => s.updateDrag)
   const endDrag = usePlanet(s => s.endDrag)
@@ -171,6 +232,7 @@ export function Interaction() {
       if (cx < 0 || cy < 0 || cx > width() || cy > height()) {
         setOnPlanet(false)
         onPlanetRef.current = false
+        setHoveredTile(null)
         return
       }
 
@@ -178,6 +240,10 @@ export function Interaction() {
       const near = hit || rayMissesPlanetButNearRing()
       setOnPlanet(near)
       onPlanetRef.current = near
+      // Publish hovered tile for the keyboard-rotation hybrid. Only set when
+      // the ray actually hits the planet surface; the padded-ring region isn't
+      // a tile, so pressing a key there would be ambiguous.
+      setHoveredTile(hit ? sphereHitToTile(_hit) : null)
     }
 
     const onDown = (e: PointerEvent) => {
@@ -208,17 +274,40 @@ export function Interaction() {
       if (wasCommitted) void endDrag()
     }
 
+    const onKey = (e: KeyboardEvent) => {
+      // Ignore modifiers (let browser shortcuts pass) and typing contexts.
+      if (e.ctrlKey || e.metaKey || e.altKey) return
+      const tgt = e.target as HTMLElement | null
+      if (tgt && (tgt.tagName === 'INPUT' || tgt.tagName === 'TEXTAREA' || tgt.isContentEditable)) return
+
+      const key = e.key.toLowerCase()
+      if (!['q', 'w', 'e', 'a', 's', 'd'].includes(key)) return
+
+      const s = usePlanet.getState()
+      if (s.anim || s.drag) return // rotation already in flight
+      const ht = s.hoveredTile
+      if (!ht) return // nothing hovered
+
+      const move = moveFromKey(key, FACES[ht.face], { u: ht.u, v: ht.v })
+      if (!move) return
+
+      e.preventDefault()
+      void s.rotateAnimated(move)
+    }
+
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerdown', onDown, { capture: true })
     window.addEventListener('pointerup', onUp)
     window.addEventListener('pointercancel', onUp)
+    window.addEventListener('keydown', onKey)
     return () => {
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerdown', onDown, { capture: true })
       window.removeEventListener('pointerup', onUp)
       window.removeEventListener('pointercancel', onUp)
+      window.removeEventListener('keydown', onKey)
     }
-  }, [camera, gl, size.width, size.height, setOnPlanet, beginDragAt, updateDrag, endDrag])
+  }, [camera, gl, size.width, size.height, setOnPlanet, setHoveredTile, beginDragAt, updateDrag, endDrag])
 
   return null
 }

--- a/src/world/Interaction.tsx
+++ b/src/world/Interaction.tsx
@@ -4,6 +4,7 @@ import * as THREE from 'three'
 import { usePlanet } from './store'
 import { centroidToFaceUV, tileCentroid, type Axis, type Direction, type Move } from './rotation'
 import { FACES, type FaceDef, type FaceIndex } from './faces'
+import { hudUniforms } from '../diorama/buildDiorama'
 
 // Pointer input lives here because both onPlanet tracking and drag-axis
 // resolution need the live camera for raycasting.
@@ -224,15 +225,18 @@ export function Interaction() {
 
       // No drag in progress — update onPlanet for orbit gating
       const tgt = e.target as HTMLElement | null
-      if (tgt && tgt.closest('[id^="leva"]')) {
+      if (tgt && typeof tgt.closest === 'function' && tgt.closest('[id^="leva"]')) {
         setOnPlanet(false)
         onPlanetRef.current = false
+        setHoveredTile(null)
+        hudUniforms.uHudCursorActive.value = 0
         return
       }
       if (cx < 0 || cy < 0 || cx > width() || cy > height()) {
         setOnPlanet(false)
         onPlanetRef.current = false
         setHoveredTile(null)
+        hudUniforms.uHudCursorActive.value = 0
         return
       }
 
@@ -244,6 +248,15 @@ export function Interaction() {
       // the ray actually hits the planet surface; the padded-ring region isn't
       // a tile, so pressing a key there would be ambiguous.
       setHoveredTile(hit ? sphereHitToTile(_hit) : null)
+      // Publish cursor world-pos to the HUD shader directly (no store churn
+      // per pointermove). When off-planet, mark cursor inactive so the
+      // terrain's gaussian proximity term zeros out.
+      if (hit) {
+        hudUniforms.uHudCursor.value.copy(_hit)
+        hudUniforms.uHudCursorActive.value = 1
+      } else {
+        hudUniforms.uHudCursorActive.value = 0
+      }
     }
 
     const onDown = (e: PointerEvent) => {

--- a/src/world/Interaction.tsx
+++ b/src/world/Interaction.tsx
@@ -90,7 +90,7 @@ function sphereHitToTile(hit: THREE.Vector3): { face: FaceIndex; u: number; v: n
 function moveFromKey(key: string, face: FaceDef, tileUV: { u: number; v: number }): Move | null {
   const centroid = tileCentroid(face.index, tileUV.u, tileUV.v)
   const resolve = (dir: THREE.Vector3): { axis: Axis; worldSign: 1 | -1 } => {
-    const ax = Math.abs(dir.x), ay = Math.abs(dir.y), az = Math.abs(dir.z)
+    const ax = Math.abs(dir.x), ay = Math.abs(dir.y)
     let axis: Axis
     if (ax > 0.5) axis = 'x'
     else if (ay > 0.5) axis = 'y'

--- a/src/world/rotation.ts
+++ b/src/world/rotation.ts
@@ -77,6 +77,43 @@ export function inverseMove(m: Move): Move {
   return { axis: m.axis, slice: m.slice, dir: -m.dir as Direction }
 }
 
+/** Static neighbor-across-edge table: for each of the 24 CURRENT cube
+ *  positions (face * 4 + v * 2 + u), the neighbor position across each of
+ *  the 4 face-local edges: [+right, -right, +up, -up]. Neighbors may live
+ *  on the same face (internal seam) or the adjacent cube face. Computed
+ *  geometrically once per module load via centroidToFaceUV on a small
+ *  outward nudge past the tile's edge centre. */
+export const NEIGHBOR_IDX: Int32Array = (() => {
+  const out = new Int32Array(24 * 4)
+  for (let idx = 0; idx < 24; idx++) {
+    const face = (idx >> 2) as FaceIndex
+    const v = (idx >> 1) & 1
+    const u = idx & 1
+    const f = FACES[face]
+    const center = tileCentroid(face, u, v)
+    const edgeDirs = [
+      f.right.clone(),
+      f.right.clone().negate(),
+      f.up.clone(),
+      f.up.clone().negate(),
+    ]
+    for (let e = 0; e < 4; e++) {
+      const dir = edgeDirs[e]
+      // Move a full CELL along the edge direction — lands either in the
+      // adjacent same-face tile center, or outside the cube in which case the
+      // max-abs component > 1. centroidToFaceUV expects max-abs = 1 (it maps
+      // s∈[-1,1] to u∈{0..N-1} and rounds; s=1 rounds to u=N which is OOB),
+      // so normalize the probe back to the cube surface before the lookup.
+      const probe = center.clone().addScaledVector(dir, 1.0)
+      const maxAbs = Math.max(Math.abs(probe.x), Math.abs(probe.y), Math.abs(probe.z))
+      probe.multiplyScalar(1 / maxAbs)
+      const n = centroidToFaceUV(probe)
+      out[idx * 4 + e] = n.face * 4 + n.v * 2 + n.u
+    }
+  }
+  return out
+})()
+
 export function randomMove(rng: () => number = Math.random, prev?: Move): Move {
   const axes: Axis[] = ['x', 'y', 'z']
   let m: Move

--- a/src/world/store.ts
+++ b/src/world/store.ts
@@ -41,6 +41,9 @@ interface PlanetStore {
    *  to false on the first successful player commit. TileGrid's useFrame
    *  reads this and eases the shader's uHudOpacity uniform 1→0. */
   hudAttractMode: boolean
+  /** Easy mode toggles per-edge correctness colors in the HUD overlay
+   *  (green = both tiles at home across this edge, red = misplaced). */
+  easyMode: boolean
   commitThreshold: number // radians; drag past this and release → commit
   aiEnabled: boolean
   aiHasFired: boolean // per-playthrough latch; resets on scramble/reset
@@ -51,6 +54,7 @@ interface PlanetStore {
   setShowRing: (v: boolean) => void
   setOnPlanet: (v: boolean) => void
   setHoveredTile: (t: HoveredTile | null) => void
+  setEasyMode: (v: boolean) => void
   setCommitThreshold: (v: number) => void
   setAiEnabled: (v: boolean) => void
   markAiFired: () => void
@@ -120,6 +124,7 @@ export const usePlanet = create<PlanetStore>((set, get) => ({
   onPlanet: false,
   hoveredTile: null,
   hudAttractMode: true,
+  easyMode: false,
   commitThreshold: (6.5 * Math.PI) / 180, // 6.5° — tuned for a light digital feel
   aiEnabled: true,
   aiHasFired: false,
@@ -129,6 +134,7 @@ export const usePlanet = create<PlanetStore>((set, get) => ({
   setShowLabels: v => set({ showLabels: v }),
   setShowRing: v => set({ showRing: v }),
   setOnPlanet: v => set(s => (s.onPlanet === v ? {} : { onPlanet: v })),
+  setEasyMode: v => set({ easyMode: v }),
   setHoveredTile: t => set(s => {
     // Shallow-equal check to skip store churn on redundant writes (pointermove
     // fires ~60Hz; most samples land on the same tile).

--- a/src/world/store.ts
+++ b/src/world/store.ts
@@ -37,6 +37,10 @@ interface PlanetStore {
   showRing: boolean
   onPlanet: boolean
   hoveredTile: HoveredTile | null
+  /** True at t=0 (HUD covers entire planet as a tutorial attract). Flips
+   *  to false on the first successful player commit. TileGrid's useFrame
+   *  reads this and eases the shader's uHudOpacity uniform 1→0. */
+  hudAttractMode: boolean
   commitThreshold: number // radians; drag past this and release → commit
   aiEnabled: boolean
   aiHasFired: boolean // per-playthrough latch; resets on scramble/reset
@@ -86,7 +90,7 @@ let animCounter = 0
 let animResolver: (() => void) | null = null
 
 function applyRotation(
-  s: Pick<PlanetStore, 'tiles' | 'solved' | 'history'>,
+  s: Pick<PlanetStore, 'tiles' | 'solved' | 'history' | 'hudAttractMode'>,
   axis: Axis,
   slice: number,
   dir: Direction,
@@ -100,6 +104,9 @@ function applyRotation(
     tiles: newTiles,
     solved: nowSolved,
     history: [...s.history, { axis, slice, dir }],
+    // First player commit retires attract mode. TileGrid eases the shader
+    // uniform from 1 → 0 over ~1 s.
+    hudAttractMode: s.hudAttractMode ? false : s.hudAttractMode,
   }
 }
 
@@ -112,6 +119,7 @@ export const usePlanet = create<PlanetStore>((set, get) => ({
   showRing: false,
   onPlanet: false,
   hoveredTile: null,
+  hudAttractMode: true,
   commitThreshold: (6.5 * Math.PI) / 180, // 6.5° — tuned for a light digital feel
   aiEnabled: true,
   aiHasFired: false,

--- a/src/world/store.ts
+++ b/src/world/store.ts
@@ -1,6 +1,17 @@
 import { create } from 'zustand'
 import { buildSolvedTiles, isSolved, type Tile } from './tile'
 import { rotateSlice, randomMove, inverseMove, type Axis, type Direction, type Move } from './rotation'
+import type { FaceIndex } from './faces'
+
+/** Which tile the cursor is over, in current cube coordinates. Drives the
+ *  hover-to-key rotation hybrid: hover a tile, press Q/W/E/A/S/D → rotate the
+ *  slice containing it around a face-local axis. Set by Interaction.tsx on
+ *  pointermove raycasts; null when the cursor is off the planet. */
+export interface HoveredTile {
+  face: FaceIndex
+  u: number
+  v: number
+}
 
 export interface AnimState {
   id: number
@@ -25,6 +36,7 @@ interface PlanetStore {
   showLabels: boolean
   showRing: boolean
   onPlanet: boolean
+  hoveredTile: HoveredTile | null
   commitThreshold: number // radians; drag past this and release → commit
   aiEnabled: boolean
   aiHasFired: boolean // per-playthrough latch; resets on scramble/reset
@@ -34,6 +46,7 @@ interface PlanetStore {
   setShowLabels: (v: boolean) => void
   setShowRing: (v: boolean) => void
   setOnPlanet: (v: boolean) => void
+  setHoveredTile: (t: HoveredTile | null) => void
   setCommitThreshold: (v: number) => void
   setAiEnabled: (v: boolean) => void
   markAiFired: () => void
@@ -98,6 +111,7 @@ export const usePlanet = create<PlanetStore>((set, get) => ({
   showLabels: false,
   showRing: false,
   onPlanet: false,
+  hoveredTile: null,
   commitThreshold: (6.5 * Math.PI) / 180, // 6.5° — tuned for a light digital feel
   aiEnabled: true,
   aiHasFired: false,
@@ -107,6 +121,14 @@ export const usePlanet = create<PlanetStore>((set, get) => ({
   setShowLabels: v => set({ showLabels: v }),
   setShowRing: v => set({ showRing: v }),
   setOnPlanet: v => set(s => (s.onPlanet === v ? {} : { onPlanet: v })),
+  setHoveredTile: t => set(s => {
+    // Shallow-equal check to skip store churn on redundant writes (pointermove
+    // fires ~60Hz; most samples land on the same tile).
+    const a = s.hoveredTile
+    if (a === t) return {}
+    if (a && t && a.face === t.face && a.u === t.u && a.v === t.v) return {}
+    return { hoveredTile: t }
+  }),
   setCommitThreshold: v => set({ commitThreshold: v }),
   setAiEnabled: v => set({ aiEnabled: v }),
   markAiFired: () => set({ aiHasFired: true }),

--- a/tests/hud-easy.mjs
+++ b/tests/hud-easy.mjs
@@ -1,0 +1,49 @@
+import { chromium } from 'playwright'
+const URL = process.env.URL || 'http://localhost:5176/'
+const browser = await chromium.launch()
+const ctx = await browser.newContext({ viewport: { width: 1800, height: 1200 }, deviceScaleFactor: 2 })
+const page = await ctx.newPage()
+page.on('pageerror', e => console.log('[PAGEERROR]', e.message))
+await page.goto(URL)
+await page.waitForTimeout(3000)
+
+const r3fBox = await page.evaluate(() => {
+  const cs = Array.from(document.querySelectorAll('canvas'))
+  let best = cs[0], bestArea = 0
+  for (const c of cs) {
+    const r = c.getBoundingClientRect()
+    const a = r.width * r.height
+    if (a > bestArea) { bestArea = a; best = c }
+  }
+  const r = best.getBoundingClientRect()
+  return { x: r.x, y: r.y, width: r.width, height: r.height }
+})
+const cx = r3fBox.x + r3fBox.width / 2
+const cy = r3fBox.y + r3fBox.height / 2
+
+await page.evaluate(() => window.__planet.getState().setEasyMode(true))
+
+for (let i = 0; i < 30; i++) {
+  await page.mouse.move(cx, cy)
+  await page.mouse.wheel(0, -400)
+  await page.waitForTimeout(20)
+}
+await page.waitForTimeout(500)
+
+// Scrambled — all red at tile edges
+await page.screenshot({ path: '/tmp/rubics-test/hud-easy-zoom-scrambled.png' })
+
+// Solve — all green at tile edges
+await page.evaluate(() => window.__planet.getState().solve())
+await page.waitForTimeout(600)
+await page.mouse.move(cx, cy)
+await page.waitForTimeout(400)
+await page.screenshot({ path: '/tmp/rubics-test/hud-easy-zoom-solved.png' })
+
+// One move from solved
+await page.keyboard.press('q')
+await page.waitForTimeout(700)
+await page.screenshot({ path: '/tmp/rubics-test/hud-easy-zoom-onemove.png' })
+
+console.log('done')
+await browser.close()

--- a/tests/hud-lines.mjs
+++ b/tests/hud-lines.mjs
@@ -1,0 +1,55 @@
+import { chromium } from 'playwright'
+const URL = process.env.URL || 'http://localhost:5176/'
+const browser = await chromium.launch()
+const ctx = await browser.newContext({ viewport: { width: 1800, height: 1200 }, deviceScaleFactor: 2 })
+const page = await ctx.newPage()
+page.on('pageerror', e => console.log('[PAGEERROR]', e.message))
+await page.goto(URL)
+await page.waitForTimeout(3000)
+
+const r3fBox = await page.evaluate(() => {
+  const cs = Array.from(document.querySelectorAll('canvas'))
+  let best = cs[0], bestArea = 0
+  for (const c of cs) {
+    const r = c.getBoundingClientRect()
+    const a = r.width * r.height
+    if (a > bestArea) { bestArea = a; best = c }
+  }
+  const r = best.getBoundingClientRect()
+  return { x: r.x, y: r.y, width: r.width, height: r.height }
+})
+const cx = r3fBox.x + r3fBox.width / 2
+const cy = r3fBox.y + r3fBox.height / 2
+
+// Attract mode (fresh load)
+await page.screenshot({ path: '/tmp/rubics-test/hud-lines-attract.png' })
+
+// Solve + zoom
+await page.evaluate(() => window.__planet.getState().solve())
+await page.waitForTimeout(500)
+
+for (let i = 0; i < 25; i++) {
+  await page.mouse.move(cx, cy)
+  await page.mouse.wheel(0, -400)
+  await page.waitForTimeout(20)
+}
+await page.waitForTimeout(500)
+await page.screenshot({ path: '/tmp/rubics-test/hud-lines-solved-attract.png' })
+
+// Easy mode on
+await page.evaluate(() => window.__planet.getState().setEasyMode(true))
+await page.waitForTimeout(1200)
+await page.screenshot({ path: '/tmp/rubics-test/hud-lines-solved-easy.png' })
+
+// One move to scramble partially
+await page.keyboard.press('q')
+await page.waitForTimeout(700)
+await page.screenshot({ path: '/tmp/rubics-test/hud-lines-onemove-easy.png' })
+
+// Turn easy off — should fade back to pure yellow lines
+await page.evaluate(() => window.__planet.getState().setEasyMode(false))
+await page.waitForTimeout(1200)
+await page.screenshot({ path: '/tmp/rubics-test/hud-lines-onemove-yellow.png' })
+
+console.log('done')
+await browser.close()

--- a/tests/hud-observe.mjs
+++ b/tests/hud-observe.mjs
@@ -1,0 +1,47 @@
+import { chromium } from 'playwright'
+const URL = process.env.URL || 'http://localhost:5176/'
+const browser = await chromium.launch()
+const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } })
+const page = await ctx.newPage()
+page.on('pageerror', e => console.log('[PAGEERROR]', e.message))
+page.on('console', m => { if (m.type() === 'error') console.log('[err]', m.text()) })
+await page.goto(URL)
+await page.waitForTimeout(3000)
+
+// Fresh load — HUD should cover the whole planet.
+await page.screenshot({ path: '/tmp/rubics-test/hud-attract.png' })
+
+const r3fBox = await page.evaluate(() => {
+  const cs = Array.from(document.querySelectorAll('canvas'))
+  let best = cs[0], bestArea = 0
+  for (const c of cs) {
+    const r = c.getBoundingClientRect()
+    const a = r.width * r.height
+    if (a > bestArea) { bestArea = a; best = c }
+  }
+  const r = best.getBoundingClientRect()
+  return { x: r.x, y: r.y, width: r.width, height: r.height }
+})
+const cx = r3fBox.x + r3fBox.width / 2
+const cy = r3fBox.y + r3fBox.height / 2
+
+await page.mouse.move(cx, cy)
+await page.waitForTimeout(200)
+await page.screenshot({ path: '/tmp/rubics-test/hud-hover.png' })
+
+// Press Q to trigger first commit → attract fades
+await page.keyboard.press('q')
+await page.waitForTimeout(1500) // wait for anim + HUD fade
+await page.screenshot({ path: '/tmp/rubics-test/hud-postcommit.png' })
+
+// Move cursor off-planet then back
+await page.mouse.move(100, 100)
+await page.waitForTimeout(400)
+await page.screenshot({ path: '/tmp/rubics-test/hud-cursor-off.png' })
+
+await page.mouse.move(cx, cy)
+await page.waitForTimeout(300)
+await page.screenshot({ path: '/tmp/rubics-test/hud-cursor-on.png' })
+
+console.log('done')
+await browser.close()

--- a/tests/kbd-rotate.mjs
+++ b/tests/kbd-rotate.mjs
@@ -1,0 +1,73 @@
+import { chromium } from 'playwright'
+const URL = process.env.URL || 'http://localhost:5176/'
+const browser = await chromium.launch()
+const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } })
+const page = await ctx.newPage()
+page.on('pageerror', e => console.log('[PAGEERROR]', e.message))
+page.on('console', m => { if (m.type() === 'error') console.log('[err]', m.text()) })
+await page.goto(URL)
+await page.waitForTimeout(3000)
+
+// Target the R3F canvas (largest canvas on page).
+const r3fBox = await page.evaluate(() => {
+  const canvases = Array.from(document.querySelectorAll('canvas'))
+  let best = canvases[0], bestArea = 0
+  for (const c of canvases) {
+    const r = c.getBoundingClientRect()
+    const area = r.width * r.height
+    if (area > bestArea) { bestArea = area; best = c }
+  }
+  const r = best.getBoundingClientRect()
+  return { x: r.x, y: r.y, width: r.width, height: r.height }
+})
+const cx = r3fBox.x + r3fBox.width / 2
+const cy = r3fBox.y + r3fBox.height / 2
+console.log('r3f canvas:', r3fBox, 'target:', cx, cy)
+
+const readTiles = () => page.evaluate(() =>
+  window.__planet.getState().tiles.map(t => ({ h: t.homeFace, f: t.face, u: t.u, v: t.v })))
+
+await page.mouse.move(cx, cy)
+await page.waitForTimeout(300)
+
+const hovered = await page.evaluate(() => window.__planet.getState().hoveredTile)
+console.log('hovered:', hovered)
+
+const before = await readTiles()
+
+// Q
+await page.keyboard.press('q')
+await page.waitForTimeout(500)
+const afterQ = await readTiles()
+console.log('Q changed:', JSON.stringify(before) !== JSON.stringify(afterQ))
+
+// E (undo Q)
+await page.keyboard.press('e')
+await page.waitForTimeout(500)
+const afterE = await readTiles()
+console.log('E restored:', JSON.stringify(before) === JSON.stringify(afterE))
+
+// W, S
+await page.mouse.move(cx, cy)
+await page.waitForTimeout(100)
+await page.keyboard.press('w')
+await page.waitForTimeout(500)
+await page.keyboard.press('s')
+await page.waitForTimeout(500)
+const afterWS = await readTiles()
+console.log('W then S restored:', JSON.stringify(before) === JSON.stringify(afterWS))
+
+// A, D
+await page.mouse.move(cx, cy)
+await page.waitForTimeout(100)
+await page.keyboard.press('a')
+await page.waitForTimeout(500)
+await page.keyboard.press('d')
+await page.waitForTimeout(500)
+const afterAD = await readTiles()
+console.log('A then D restored:', JSON.stringify(before) === JSON.stringify(afterAD))
+
+await page.screenshot({ path: '/tmp/rubics-test/kbd-rotate.png' })
+
+console.log('done')
+await browser.close()


### PR DESCRIPTION
## Summary

Three-layer solution to "players don't know this is a puzzle, don't see tile topology, and have no accessibility/keyboard input path."

- **Keyboard rotation (hover + Q/W/E/A/S/D)** — face-local axis mapping on the currently-hovered tile. `sphereHitToTile` projects the unit-sphere raycast hit onto cube space and reuses `centroidToFaceUV` for the cell lookup. Both drag and keys route to the same `rotateAnimated` pipeline. Solves trackpad fatigue + gives expert players a fast input.
- **Polka-dot HUD overlay (attract + cursor reveal)** — *was* the initial shape, now swapped for line strips per design iteration. Global `uHudOpacity` covers the planet at t=0 as a tutorial surface; flips to hover-only after the first committed rotation; cursor world-pos published directly to the terrain's triplanar fragment shader (no store churn per mousemove). Easing handled in `TileGrid.useFrame`.
- **Yellow tile-edge line HUD** — final visual. **Thin** strokes at cube face-boundary edges (cosmetic, within-cubie seams); **thick** strokes at face-internal mid-face seams (the three great circles where slice rotations shear). Style-agnostic — survives any diorama content swap. Corner-fade suppresses 3-face-junction speckle from per-fragment face classification flicker.
- **Easy-mode correctness colors (L3)** — toggle via Leva. Lines tint green (both tiles at home across this edge) or red (wrong). Driven by `uHudTileEdgeMask[96]` computed each frame from `tiles` + a static `NEIGHBOR_IDX` lookup (built via `centroidToFaceUV` on a cube-surface-normalized probe — naive probes landed outside the unit cube at face-crossings, breaking the `round()` math).

## Test plan

- [x] `tsc -b` clean
- [x] `vite build` clean (1.74 MB → 556 KB gzipped)
- [x] `tests/kbd-rotate.mjs` — Q↔E, W↔S, A↔D verified as exact inverses
- [x] `tests/hud-observe.mjs` — attract mode covers planet; fades after keypress; cursor reveal after
- [x] `tests/hud-easy.mjs` — NEIGHBOR_IDX no invalid entries; solved-state mask all zero; scrambled-state mask populated
- [x] `tests/hud-lines.mjs` — thick/thin lines in attract + post-commit + easy-mode states
- [ ] Manual: keyboard + drag feel consistent on the deploy URL

## Notes for review

- Bundle still exceeds 500 KB warning — separate perf phase.
- Pink specks visible in some screenshots are the starling flock lit by the sunset HDRI, NOT HUD artifacts.
- Next: walk mode (Day 7 per PHASE_1.md).