### PR TITLE
Walk mode: first-person on-planet exploration + HDRI persistence fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback } from 'react'
-import { Canvas } from '@react-three/fiber'
+import { useState, useCallback, useEffect } from 'react'
+import { Canvas, useThree } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
 import * as THREE from 'three'
 import { Ring } from './world/Ring'
@@ -17,11 +17,13 @@ import { Controls } from './Controls'
 import { usePlanet } from './world/store'
 import { NEIGHBOR_IDX } from './world/rotation'
 import { hudUniforms } from './diorama/buildDiorama'
+import { useHdri } from './world/hdriStore'
 
 if (import.meta.env.DEV && typeof window !== 'undefined') {
   ;(window as unknown as Record<string, unknown>).__planet = usePlanet
   ;(window as unknown as Record<string, unknown>).__neighborIdx = NEIGHBOR_IDX
   ;(window as unknown as Record<string, unknown>).__hud = hudUniforms
+  ;(window as unknown as Record<string, unknown>).__hdri = useHdri
 }
 
 function Cursor() {
@@ -52,6 +54,17 @@ function SphereCamera() {
   )
 }
 
+function DevSceneExpose() {
+  // Dev helper: expose the R3F scene to window for debugging HDRI state.
+  const { scene } = useThree()
+  useEffect(() => {
+    if (import.meta.env.DEV) {
+      ;(window as unknown as Record<string, unknown>).__scene = scene
+    }
+  }, [scene])
+  return null
+}
+
 export default function App() {
   const [preview, setPreview] = useState<false | 'grid' | 'split' | 'cube'>(false)
   const [bezier, setBezier] = useState({ cx1: 0.25, cy1: 0.1, cx2: 0.75, cy2: 0.9 })
@@ -77,6 +90,7 @@ export default function App() {
         dpr={[1, 2]}
       >
         <color attach="background" args={['#0a0d12']} />
+        <DevSceneExpose />
         {preview === 'grid' ? (
           <>
             <DioramaGrid />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { OrbitControls } from '@react-three/drei'
 import * as THREE from 'three'
 import { Ring } from './world/Ring'
 import { Interaction } from './world/Interaction'
+import { WalkControls } from './world/WalkControls'
 import { AiSeed } from './world/AiSeed'
 import { PostFx } from './world/PostFx'
 import { TileLabels, TileLabelsLegend } from './world/TileLabels'
@@ -29,6 +30,25 @@ function Cursor() {
   const cursor = drag ? 'grabbing' : onPlanet ? 'grab' : 'default'
   return (
     <style>{`canvas { cursor: ${cursor}; }`}</style>
+  )
+}
+
+function SphereCamera() {
+  // OrbitControls for third-person orbit around the planet. Unmounted when
+  // walk mode is active so it doesn't fight WalkControls for the camera.
+  const cameraMode = usePlanet(s => s.cameraMode)
+  if (cameraMode === 'walk') return null
+  return (
+    <OrbitControls
+      key="sphere"
+      makeDefault
+      enablePan={false}
+      minDistance={2.5}
+      maxDistance={8}
+      rotateSpeed={0.8}
+      enableDamping
+      dampingFactor={0.08}
+    />
   )
 }
 
@@ -78,6 +98,7 @@ export default function App() {
             <AiSeed />
             <TileLabels mode="sphere" />
             <PostFx />
+            <WalkControls />
           </>
         )}
         {preview ? (
@@ -94,19 +115,11 @@ export default function App() {
             maxDistance={60}
           />
         ) : (
-          // OrbitControls for sphere — feels more natural (polar locking is
-          // a feature, not a bug, for a grounded "planet" sim). Trackball's
-          // free-roll past the poles disoriented more than it helped.
-          <OrbitControls
-            key="sphere"
-            makeDefault
-            enablePan={false}
-            minDistance={2.5}
-            maxDistance={8}
-            rotateSpeed={0.8}
-            enableDamping
-            dampingFactor={0.08}
-          />
+          // Sphere-mode camera routing: OrbitControls for third-person orbit,
+          // auto-unmounted when WalkControls takes over. Polar-lock is a
+          // feature for a grounded planet sim (Trackball's free-roll past the
+          // poles disoriented more than it helped).
+          <SphereCamera />
         )}
       </Canvas>
     </>

--- a/src/Controls.tsx
+++ b/src/Controls.tsx
@@ -22,12 +22,19 @@ export function Controls({
   const setCommitThreshold = usePlanet(s => s.setCommitThreshold)
   const setAiEnabled = usePlanet(s => s.setAiEnabled)
   const setEasyMode = usePlanet(s => s.setEasyMode)
+  const setCameraMode = usePlanet(s => s.setCameraMode)
 
   useControls({
     'View: Cube net': button(() => setDioramaPreview(dioramaPreview === 'grid' ? false : 'grid')),
     'View: Split': button(() => setDioramaPreview(dioramaPreview === 'split' ? false : 'split')),
     'View: Cube': button(() => setDioramaPreview(dioramaPreview === 'cube' ? false : 'cube')),
     'View: Sphere (planet)': button(() => setDioramaPreview(false)),
+    'Walk on planet': button(() => {
+      // Must stay in sphere mode — WalkControls only mounts under <Canvas>'s
+      // sphere branch.
+      setDioramaPreview(false)
+      setCameraMode('walk')
+    }),
     Ring: {
       value: false,
       onChange: (v: boolean) => setShowRing(v),

--- a/src/world/HDRIEnvironment.tsx
+++ b/src/world/HDRIEnvironment.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react'
-import { useThree } from '@react-three/fiber'
+import { useThree, useFrame } from '@react-three/fiber'
 import { Environment } from '@react-three/drei'
 import * as THREE from 'three'
 import { useHdri } from './hdriStore'
@@ -42,10 +42,13 @@ export function HDRIEnvironment() {
   const setEnvTexture = useHdri(s => s.setEnvTexture)
   const useUniform = !url && preset === 'uniform'
 
-  // Push live HDRI parameters onto the scene. three r155+ supports these
-  // scene-level properties directly; doing it imperatively sidesteps drei's
-  // Environment prop surface which varies by version.
-  useEffect(() => {
+  // Push live HDRI parameters onto the scene EVERY FRAME. Reacting to store
+  // changes alone isn't sufficient — sibling mounts (drei's <Environment>,
+  // OrbitControls with makeDefault, etc.) intermittently reset scene-level
+  // intensity/blur/rotation to three.js defaults without re-triggering our
+  // store selectors. A per-frame push keeps the scene in sync regardless of
+  // who else writes. Cost: 6 property assignments per frame, negligible.
+  useFrame(() => {
     scene.backgroundBlurriness = blur
     scene.environmentIntensity = intensity
     scene.backgroundIntensity = backgroundOpacity
@@ -53,7 +56,7 @@ export function HDRIEnvironment() {
     if (!scene.environmentRotation) scene.environmentRotation = new THREE.Euler()
     scene.backgroundRotation.set(0, rotation, 0)
     scene.environmentRotation.set(0, rotation, 0)
-  }, [scene, blur, intensity, rotation, backgroundOpacity])
+  })
 
   // Publish the currently-active environment texture to the store every
   // frame scene.environment might change. Using a short interval is cheap

--- a/src/world/Interaction.tsx
+++ b/src/world/Interaction.tsx
@@ -158,6 +158,9 @@ export function Interaction() {
     }
 
     const onMove = (e: PointerEvent) => {
+      // Walk mode owns the cursor (pointer-lock) and camera — don't run any
+      // orbit-mode pointer interaction while it's active.
+      if (usePlanet.getState().cameraMode === 'walk') return
       const rect = canvas.getBoundingClientRect()
       const cx = e.clientX - rect.left
       const cy = e.clientY - rect.top
@@ -261,8 +264,9 @@ export function Interaction() {
 
     const onDown = (e: PointerEvent) => {
       if (e.button !== 0) return
+      if (usePlanet.getState().cameraMode === 'walk') return
       const tgt = e.target as HTMLElement | null
-      if (tgt && tgt.closest('[id^="leva"]')) return
+      if (tgt && typeof tgt.closest === 'function' && tgt.closest('[id^="leva"]')) return
 
       const rect = canvas.getBoundingClientRect()
       const cx = e.clientX - rect.left
@@ -297,6 +301,8 @@ export function Interaction() {
       if (!['q', 'w', 'e', 'a', 's', 'd'].includes(key)) return
 
       const s = usePlanet.getState()
+      // WalkControls owns Q/W/E/A/S/D while walking — don't fire slice rotations.
+      if (s.cameraMode === 'walk') return
       if (s.anim || s.drag) return // rotation already in flight
       const ht = s.hoveredTile
       if (!ht) return // nothing hovered

--- a/src/world/WalkControls.tsx
+++ b/src/world/WalkControls.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useRef } from 'react'
+import { useThree, useFrame } from '@react-three/fiber'
+import * as THREE from 'three'
+import { usePlanet } from './store'
+
+/**
+ * First-person surface walk on the planet.
+ *
+ * Camera invariants while mounted:
+ *   • position = normalize(p) * (PLANET_R + PLAYER_H)  — always at head
+ *     height above the surface along the local radial normal.
+ *   • up = normalize(position) — gravity points to planet centre, so "up"
+ *     for the camera is the surface normal at our current spot.
+ *   • forward is maintained explicitly (not derived from rotation) and
+ *     projected onto the tangent plane each frame; drift-corrected so it
+ *     doesn't slide into the normal direction.
+ *
+ * Input:
+ *   • Mouse move (pointer-locked) → yaw around normal, pitch around local
+ *     right. Pitch clamped so forward never collapses onto up.
+ *   • W/A/S/D → translate along forward / right / -forward / -right in
+ *     the tangent plane. Snap back to sphere surface after each step.
+ *   • Tab → exit walk mode.
+ *   • Pointer-lock release (Esc) → also exits.
+ */
+
+const PLANET_R = 1.0
+const PLAYER_H = 0.08   // small-world scale — matches pocket-planet vibe
+const WALK_SPEED = 0.3  // world units per second (~20 s to walk the equator)
+const MOUSE_YAW   = 0.0025
+const MOUSE_PITCH = 0.0025
+const PITCH_LIMIT = 0.97 // clamp |dot(forward, up)| so pitch stops short of vertical
+
+export function WalkControls() {
+  const { camera, gl } = useThree()
+  const cameraMode = usePlanet(s => s.cameraMode)
+  const setCameraMode = usePlanet(s => s.setCameraMode)
+
+  // Persistent state across frames. Initialized on mount.
+  const posRef = useRef<THREE.Vector3>(new THREE.Vector3(0, PLANET_R + PLAYER_H, 0))
+  const fwdRef = useRef<THREE.Vector3>(new THREE.Vector3(0, 0, -1))
+  const keysRef = useRef<Set<string>>(new Set())
+  // Tracks whether pointer-lock was ever actually granted — so onLockChange
+  // can distinguish "user released lock" from "lock was never granted".
+  const hadLockRef = useRef(false)
+
+  useEffect(() => {
+    if (cameraMode !== 'walk') return
+
+    // Entry: spawn the player at the camera's current direction projected
+    // to the sphere surface. Feels continuous with wherever they were
+    // orbiting from. Forward = tangent in the direction the camera was facing.
+    const camPos = camera.position.clone()
+    const normal = camPos.clone().normalize()
+    posRef.current.copy(normal).multiplyScalar(PLANET_R + PLAYER_H)
+    // Forward: take the camera's current -Z direction, project into the
+    // tangent plane, normalize. Fallback to a stable cross if degenerate.
+    const camFwd = new THREE.Vector3()
+    camera.getWorldDirection(camFwd) // unit, looking from camera into scene
+    camFwd.addScaledVector(normal, -camFwd.dot(normal))
+    if (camFwd.lengthSq() < 1e-4) {
+      // Camera was aimed straight at the planet centre — pick any tangent.
+      camFwd.set(1, 0, 0).addScaledVector(normal, -normal.x).normalize()
+    } else {
+      camFwd.normalize()
+    }
+    fwdRef.current.copy(camFwd)
+
+    // Request pointer lock — improves mouse-look by uncapping the cursor
+    // from screen bounds. Browsers only grant this from a user gesture, so
+    // this may silently fail in headless or if the entry trigger wasn't a
+    // click. Walk mode still works without lock; mouse-delta is smaller
+    // since the cursor hits screen edges. Don't bail on failure.
+    const canvas = gl.domElement
+    const requestLock = async () => {
+      try { await canvas.requestPointerLock() } catch { /* ignore */ }
+    }
+    void requestLock()
+
+    const onMouseMove = (e: MouseEvent) => {
+      if (document.pointerLockElement !== canvas) return
+      const up = posRef.current.clone().normalize()
+      // Yaw: rotate forward around the up axis (negative movementX feels natural).
+      fwdRef.current.applyAxisAngle(up, -e.movementX * MOUSE_YAW)
+      // Pitch: rotate forward around local right axis.
+      const right = new THREE.Vector3().crossVectors(fwdRef.current, up)
+      if (right.lengthSq() > 1e-8) {
+        right.normalize()
+        fwdRef.current.applyAxisAngle(right, -e.movementY * MOUSE_PITCH)
+      }
+      // Clamp pitch so forward doesn't collide with up.
+      const dotUp = fwdRef.current.dot(up)
+      if (Math.abs(dotUp) > PITCH_LIMIT) {
+        // Remove the excess, re-normalize in the tangent plane, add back
+        // up-component at the limit.
+        const sign = dotUp > 0 ? 1 : -1
+        const tangent = fwdRef.current.clone().addScaledVector(up, -dotUp)
+        if (tangent.lengthSq() > 1e-8) tangent.normalize()
+        else tangent.copy(right) // safety fallback
+        fwdRef.current.copy(tangent.multiplyScalar(Math.sqrt(1 - PITCH_LIMIT * PITCH_LIMIT)))
+          .addScaledVector(up, sign * PITCH_LIMIT)
+      }
+    }
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      const tgt = e.target as HTMLElement | null
+      if (tgt && (tgt.tagName === 'INPUT' || tgt.tagName === 'TEXTAREA' || tgt.isContentEditable)) return
+      if (e.key === 'Tab' || e.key === 'Escape') {
+        e.preventDefault()
+        setCameraMode('orbit')
+        return
+      }
+      keysRef.current.add(e.key.toLowerCase())
+    }
+    const onKeyUp = (e: KeyboardEvent) => {
+      keysRef.current.delete(e.key.toLowerCase())
+    }
+
+    const onLockChange = () => {
+      // If the user pressed Esc to exit pointer lock, also exit walk mode.
+      // Only fires when we HAD the lock and lost it — so this doesn't fire
+      // when lock was never granted in the first place (headless / non-gesture).
+      if (hadLockRef.current && document.pointerLockElement !== canvas && usePlanet.getState().cameraMode === 'walk') {
+        setCameraMode('orbit')
+      }
+      hadLockRef.current = document.pointerLockElement === canvas
+    }
+
+    window.addEventListener('mousemove', onMouseMove)
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('keyup', onKeyUp)
+    document.addEventListener('pointerlockchange', onLockChange)
+
+    return () => {
+      window.removeEventListener('mousemove', onMouseMove)
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keyup', onKeyUp)
+      document.removeEventListener('pointerlockchange', onLockChange)
+      keysRef.current.clear()
+      if (document.pointerLockElement === canvas) document.exitPointerLock()
+      // Restore a comfortable third-person orbit distance. OrbitControls
+      // remounts on next frame and takes over from here; we want the camera
+      // to end up pulled back from the surface along the last-looked direction
+      // so the transition reads as "stepping back from where you were."
+      const exitDir = posRef.current.clone().normalize()
+      camera.position.copy(exitDir).multiplyScalar(4.0)
+      camera.up.set(0, 1, 0)
+      camera.lookAt(0, 0, 0)
+    }
+  }, [cameraMode, camera, gl, setCameraMode])
+
+  useFrame((_, dt) => {
+    if (cameraMode !== 'walk') return
+    const up = posRef.current.clone().normalize()
+    // Drift correction: project forward onto the tangent plane and
+    // renormalize so it doesn't accumulate a radial component.
+    fwdRef.current.addScaledVector(up, -fwdRef.current.dot(up))
+    if (fwdRef.current.lengthSq() < 1e-8) {
+      fwdRef.current.set(1, 0, 0).addScaledVector(up, -up.x)
+    }
+    fwdRef.current.normalize()
+
+    const right = new THREE.Vector3().crossVectors(fwdRef.current, up).normalize()
+
+    const keys = keysRef.current
+    const move = new THREE.Vector3()
+    if (keys.has('w')) move.add(fwdRef.current)
+    if (keys.has('s')) move.addScaledVector(fwdRef.current, -1)
+    if (keys.has('d')) move.add(right)
+    if (keys.has('a')) move.addScaledVector(right, -1)
+    if (move.lengthSq() > 1e-8) {
+      move.normalize().multiplyScalar(WALK_SPEED * dt)
+      posRef.current.add(move)
+      // Snap back to surface at player head height.
+      posRef.current.normalize().multiplyScalar(PLANET_R + PLAYER_H)
+    }
+
+    camera.position.copy(posRef.current)
+    camera.up.copy(posRef.current).normalize()
+    const target = posRef.current.clone().add(fwdRef.current)
+    camera.lookAt(target)
+  })
+
+  return null
+}

--- a/src/world/WalkControls.tsx
+++ b/src/world/WalkControls.tsx
@@ -29,7 +29,7 @@ const PLAYER_H = 0.08   // small-world scale — matches pocket-planet vibe
 const WALK_SPEED = 0.3  // world units per second (~20 s to walk the equator)
 const MOUSE_YAW   = 0.0025
 const MOUSE_PITCH = 0.0025
-const PITCH_LIMIT = 0.97 // clamp |dot(forward, up)| so pitch stops short of vertical
+const PITCH_MAX = Math.PI * 0.48  // ~86° — stop short of vertical either way
 
 export function WalkControls() {
   const { camera, gl } = useThree()
@@ -38,7 +38,13 @@ export function WalkControls() {
 
   // Persistent state across frames. Initialized on mount.
   const posRef = useRef<THREE.Vector3>(new THREE.Vector3(0, PLANET_R + PLAYER_H, 0))
+  // Tangent-plane forward — drives WASD walking. Always strictly perpendicular
+  // to the local surface normal; drift-corrected each frame.
   const fwdRef = useRef<THREE.Vector3>(new THREE.Vector3(0, 0, -1))
+  // Look-direction pitch in radians (scalar, ±PITCH_MAX). Kept separate from
+  // fwdRef so mouse-look up/down doesn't interfere with tangent walking:
+  // drift-correcting fwdRef would otherwise wipe any pitch the user applied.
+  const pitchRef = useRef<number>(0)
   const keysRef = useRef<Set<string>>(new Set())
   // Tracks whether pointer-lock was ever actually granted — so onLockChange
   // can distinguish "user released lock" from "lock was never granted".
@@ -65,6 +71,8 @@ export function WalkControls() {
       camFwd.normalize()
     }
     fwdRef.current.copy(camFwd)
+    pitchRef.current = 0  // reset look pitch on every entry
+    keysRef.current.clear()  // drop any keys still held from orbit mode
 
     // Request pointer lock — improves mouse-look by uncapping the cursor
     // from screen bounds. Browsers only grant this from a user gesture, so
@@ -85,26 +93,17 @@ export function WalkControls() {
       const tgt = e.target as HTMLElement | null
       if (tgt && typeof tgt.closest === 'function' && tgt.closest('[id^="leva"]')) return
       const up = posRef.current.clone().normalize()
-      // Yaw: rotate forward around the up axis (negative movementX feels natural).
+      // Yaw: rotate the tangent forward around the up axis and keep it
+      // strictly in the tangent plane. Negative movementX feels natural.
       fwdRef.current.applyAxisAngle(up, -e.movementX * MOUSE_YAW)
-      // Pitch: rotate forward around local right axis.
-      const right = new THREE.Vector3().crossVectors(fwdRef.current, up)
-      if (right.lengthSq() > 1e-8) {
-        right.normalize()
-        fwdRef.current.applyAxisAngle(right, -e.movementY * MOUSE_PITCH)
-      }
-      // Clamp pitch so forward doesn't collide with up.
-      const dotUp = fwdRef.current.dot(up)
-      if (Math.abs(dotUp) > PITCH_LIMIT) {
-        // Remove the excess, re-normalize in the tangent plane, add back
-        // up-component at the limit.
-        const sign = dotUp > 0 ? 1 : -1
-        const tangent = fwdRef.current.clone().addScaledVector(up, -dotUp)
-        if (tangent.lengthSq() > 1e-8) tangent.normalize()
-        else tangent.copy(right) // safety fallback
-        fwdRef.current.copy(tangent.multiplyScalar(Math.sqrt(1 - PITCH_LIMIT * PITCH_LIMIT)))
-          .addScaledVector(up, sign * PITCH_LIMIT)
-      }
+      fwdRef.current.addScaledVector(up, -fwdRef.current.dot(up))
+      if (fwdRef.current.lengthSq() > 1e-8) fwdRef.current.normalize()
+      // Pitch: scalar accumulator, clamped. The pitched look-direction is
+      // derived in useFrame from (fwd, up, pitch) — keeping it separate from
+      // fwd means drift correction can flatten fwd without wiping pitch.
+      pitchRef.current -= e.movementY * MOUSE_PITCH
+      if (pitchRef.current >  PITCH_MAX) pitchRef.current =  PITCH_MAX
+      if (pitchRef.current < -PITCH_MAX) pitchRef.current = -PITCH_MAX
     }
 
     const onKeyDown = (e: KeyboardEvent) => {
@@ -157,8 +156,8 @@ export function WalkControls() {
   useFrame((_, dt) => {
     if (cameraMode !== 'walk') return
     const up = posRef.current.clone().normalize()
-    // Drift correction: project forward onto the tangent plane and
-    // renormalize so it doesn't accumulate a radial component.
+    // Drift correction on tangent forward. Only touches the tangent vector —
+    // pitch is in its own scalar so it's not disturbed.
     fwdRef.current.addScaledVector(up, -fwdRef.current.dot(up))
     if (fwdRef.current.lengthSq() < 1e-8) {
       fwdRef.current.set(1, 0, 0).addScaledVector(up, -up.x)
@@ -167,6 +166,9 @@ export function WalkControls() {
 
     const right = new THREE.Vector3().crossVectors(fwdRef.current, up).normalize()
 
+    // WASD walks along the TANGENT forward (unpitched), so looking up doesn't
+    // slow you down or push you off the surface. Look direction is pitched
+    // only for the camera, not for motion.
     const keys = keysRef.current
     const move = new THREE.Vector3()
     if (keys.has('w')) move.add(fwdRef.current)
@@ -180,9 +182,14 @@ export function WalkControls() {
       posRef.current.normalize().multiplyScalar(PLANET_R + PLAYER_H)
     }
 
+    // Pitched look-direction: rotate tangent forward toward up by pitchRef.
+    const cp = Math.cos(pitchRef.current)
+    const sp = Math.sin(pitchRef.current)
+    const lookDir = fwdRef.current.clone().multiplyScalar(cp).addScaledVector(up, sp)
+
     camera.position.copy(posRef.current)
-    camera.up.copy(posRef.current).normalize()
-    const target = posRef.current.clone().add(fwdRef.current)
+    camera.up.copy(up)
+    const target = posRef.current.clone().add(lookDir)
     camera.lookAt(target)
   })
 

--- a/src/world/WalkControls.tsx
+++ b/src/world/WalkControls.tsx
@@ -32,7 +32,7 @@ const MOUSE_PITCH = 0.0025
 const PITCH_MAX = Math.PI * 0.48  // ~86° — stop short of vertical either way
 
 export function WalkControls() {
-  const { camera, gl } = useThree()
+  const { camera } = useThree()
   const cameraMode = usePlanet(s => s.cameraMode)
   const setCameraMode = usePlanet(s => s.setCameraMode)
 
@@ -46,9 +46,6 @@ export function WalkControls() {
   // drift-correcting fwdRef would otherwise wipe any pitch the user applied.
   const pitchRef = useRef<number>(0)
   const keysRef = useRef<Set<string>>(new Set())
-  // Tracks whether pointer-lock was ever actually granted — so onLockChange
-  // can distinguish "user released lock" from "lock was never granted".
-  const hadLockRef = useRef(false)
 
   useEffect(() => {
     if (cameraMode !== 'walk') return
@@ -74,24 +71,19 @@ export function WalkControls() {
     pitchRef.current = 0  // reset look pitch on every entry
     keysRef.current.clear()  // drop any keys still held from orbit mode
 
-    // Request pointer lock — improves mouse-look by uncapping the cursor
-    // from screen bounds. Browsers only grant this from a user gesture, so
-    // this may silently fail in headless or if the entry trigger wasn't a
-    // click. Walk mode still works without lock; mouse-delta is smaller
-    // since the cursor hits screen edges. Don't bail on failure.
-    const canvas = gl.domElement
-    const requestLock = async () => {
-      try { await canvas.requestPointerLock() } catch { /* ignore */ }
-    }
-    void requestLock()
+    // No pointer-lock: keeps the cursor visible so HDRI / Leva / any other
+    // HUD panel remains interactive while walking. Trade-off is that mouse
+    // deltas cap out when the cursor hits the window edge — acceptable
+    // because you can re-sweep and keep turning. FPS-purity loses to
+    // letting the user tune HDRI live without exiting walk mode.
 
     const onMouseMove = (e: MouseEvent) => {
-      // Don't gate on pointer lock — mousemove.movementX/Y are populated for
-      // every mousemove event, not just locked ones. The lock just uncaps
-      // delta range. When Leva / a panel is under the cursor, skip so the
-      // user can interact with HUD without spinning the view.
+      // Only look when the cursor is over the 3D canvas. Any HUD panel
+      // (Leva, HDRIPanel, BezierCurveEditor, TileLabelsLegend, tooltips,
+      // etc.) sits above the canvas with position:fixed — those targets
+      // should remain interactive without spinning the view.
       const tgt = e.target as HTMLElement | null
-      if (tgt && typeof tgt.closest === 'function' && tgt.closest('[id^="leva"]')) return
+      if (!(tgt instanceof HTMLCanvasElement)) return
       const up = posRef.current.clone().normalize()
       // Yaw: rotate the tangent forward around the up axis and keep it
       // strictly in the tangent plane. Negative movementX feels natural.
@@ -120,28 +112,15 @@ export function WalkControls() {
       keysRef.current.delete(e.key.toLowerCase())
     }
 
-    const onLockChange = () => {
-      // If the user pressed Esc to exit pointer lock, also exit walk mode.
-      // Only fires when we HAD the lock and lost it — so this doesn't fire
-      // when lock was never granted in the first place (headless / non-gesture).
-      if (hadLockRef.current && document.pointerLockElement !== canvas && usePlanet.getState().cameraMode === 'walk') {
-        setCameraMode('orbit')
-      }
-      hadLockRef.current = document.pointerLockElement === canvas
-    }
-
     window.addEventListener('mousemove', onMouseMove)
     window.addEventListener('keydown', onKeyDown)
     window.addEventListener('keyup', onKeyUp)
-    document.addEventListener('pointerlockchange', onLockChange)
 
     return () => {
       window.removeEventListener('mousemove', onMouseMove)
       window.removeEventListener('keydown', onKeyDown)
       window.removeEventListener('keyup', onKeyUp)
-      document.removeEventListener('pointerlockchange', onLockChange)
       keysRef.current.clear()
-      if (document.pointerLockElement === canvas) document.exitPointerLock()
       // Restore a comfortable third-person orbit distance. OrbitControls
       // remounts on next frame and takes over from here; we want the camera
       // to end up pulled back from the surface along the last-looked direction
@@ -151,7 +130,7 @@ export function WalkControls() {
       camera.up.set(0, 1, 0)
       camera.lookAt(0, 0, 0)
     }
-  }, [cameraMode, camera, gl, setCameraMode])
+  }, [cameraMode, camera, setCameraMode])
 
   useFrame((_, dt) => {
     if (cameraMode !== 'walk') return

--- a/src/world/WalkControls.tsx
+++ b/src/world/WalkControls.tsx
@@ -78,7 +78,12 @@ export function WalkControls() {
     void requestLock()
 
     const onMouseMove = (e: MouseEvent) => {
-      if (document.pointerLockElement !== canvas) return
+      // Don't gate on pointer lock — mousemove.movementX/Y are populated for
+      // every mousemove event, not just locked ones. The lock just uncaps
+      // delta range. When Leva / a panel is under the cursor, skip so the
+      // user can interact with HUD without spinning the view.
+      const tgt = e.target as HTMLElement | null
+      if (tgt && typeof tgt.closest === 'function' && tgt.closest('[id^="leva"]')) return
       const up = posRef.current.clone().normalize()
       // Yaw: rotate forward around the up axis (negative movementX feels natural).
       fwdRef.current.applyAxisAngle(up, -e.movementX * MOUSE_YAW)

--- a/src/world/store.ts
+++ b/src/world/store.ts
@@ -44,6 +44,10 @@ interface PlanetStore {
   /** Easy mode toggles per-edge correctness colors in the HUD overlay
    *  (green = both tiles at home across this edge, red = misplaced). */
   easyMode: boolean
+  /** 'orbit' = third-person outside the planet (default — OrbitControls).
+   *  'walk'  = first-person on the surface, mouse-look + WASD.
+   *  Input gates (slice-rotation keys, drag-to-rotate) check this. */
+  cameraMode: 'orbit' | 'walk'
   commitThreshold: number // radians; drag past this and release → commit
   aiEnabled: boolean
   aiHasFired: boolean // per-playthrough latch; resets on scramble/reset
@@ -55,6 +59,7 @@ interface PlanetStore {
   setOnPlanet: (v: boolean) => void
   setHoveredTile: (t: HoveredTile | null) => void
   setEasyMode: (v: boolean) => void
+  setCameraMode: (v: 'orbit' | 'walk') => void
   setCommitThreshold: (v: number) => void
   setAiEnabled: (v: boolean) => void
   markAiFired: () => void
@@ -125,6 +130,7 @@ export const usePlanet = create<PlanetStore>((set, get) => ({
   hoveredTile: null,
   hudAttractMode: true,
   easyMode: false,
+  cameraMode: 'orbit',
   commitThreshold: (6.5 * Math.PI) / 180, // 6.5° — tuned for a light digital feel
   aiEnabled: true,
   aiHasFired: false,
@@ -135,6 +141,7 @@ export const usePlanet = create<PlanetStore>((set, get) => ({
   setShowRing: v => set({ showRing: v }),
   setOnPlanet: v => set(s => (s.onPlanet === v ? {} : { onPlanet: v })),
   setEasyMode: v => set({ easyMode: v }),
+  setCameraMode: v => set(s => (s.cameraMode === v ? {} : { cameraMode: v })),
   setHoveredTile: t => set(s => {
     // Shallow-equal check to skip store churn on redundant writes (pointermove
     // fires ~60Hz; most samples land on the same tile).

--- a/tests/hdri-persist.mjs
+++ b/tests/hdri-persist.mjs
@@ -1,0 +1,69 @@
+import { chromium } from 'playwright'
+const URL = process.env.URL || 'http://localhost:5176/'
+const browser = await chromium.launch()
+const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } })
+const page = await ctx.newPage()
+page.on('pageerror', e => console.log('[PAGEERROR]', e.message))
+page.on('console', m => { if (m.type() === 'log' && m.text().includes('HDRIEnv')) console.log('BROWSER:', m.text()) })
+await page.goto(URL)
+await page.waitForTimeout(3000)
+
+const snap = () => page.evaluate(() => ({
+  store: {
+    intensity: window.__hdri.getState().intensity,
+    blur: window.__hdri.getState().blur,
+    rotation: window.__hdri.getState().rotation,
+    bgOp: window.__hdri.getState().backgroundOpacity,
+    preset: window.__hdri.getState().preset,
+  },
+  scene: window.__scene ? {
+    envI: window.__scene.environmentIntensity,
+    bgI: window.__scene.backgroundIntensity,
+    blur: window.__scene.backgroundBlurriness,
+    envRotY: window.__scene.environmentRotation?.y ?? null,
+    bgRotY: window.__scene.backgroundRotation?.y ?? null,
+    hasEnv: !!window.__scene.environment,
+    hasBg: !!window.__scene.background,
+  } : 'no scene',
+  cameraMode: window.__planet.getState().cameraMode,
+}))
+
+console.log('FRESH    :', JSON.stringify(await snap()))
+
+await page.evaluate(() => {
+  window.__hdri.getState().setIntensity(3.0)
+  window.__hdri.getState().setBlur(0.6)
+  window.__hdri.getState().setRotation(1.5)
+  window.__hdri.getState().setBackgroundOpacity(0.8)
+})
+await page.waitForTimeout(300)
+console.log('AFTER SET:', JSON.stringify(await snap()))
+
+// Drag bezier
+const bez = await page.evaluate(() => {
+  const cs = Array.from(document.querySelectorAll('canvas'))
+  const small = cs.filter(c => c.width <= 400 && c.height <= 400)
+  if (!small.length) return null
+  const r = small[0].getBoundingClientRect()
+  return { x: r.x, y: r.y, w: r.width, h: r.height }
+})
+if (bez) {
+  await page.mouse.move(bez.x + 40, bez.y + 140)
+  await page.mouse.down()
+  await page.mouse.move(bez.x + 80, bez.y + 60, { steps: 6 })
+  await page.mouse.up()
+  await page.waitForTimeout(300)
+  console.log('AFTER BEZ:', JSON.stringify(await snap()))
+}
+
+const btn = page.locator('text=Walk on planet').first()
+await btn.click()
+await page.waitForTimeout(500)
+console.log('WALK     :', JSON.stringify(await snap()))
+
+// Tweak intensity while walking
+await page.evaluate(() => window.__hdri.getState().setIntensity(0.5))
+await page.waitForTimeout(300)
+console.log('WALK+SET :', JSON.stringify(await snap()))
+
+await browser.close()

--- a/tests/walk-mode.mjs
+++ b/tests/walk-mode.mjs
@@ -4,37 +4,57 @@ const browser = await chromium.launch()
 const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } })
 const page = await ctx.newPage()
 page.on('pageerror', e => console.log('[PAGEERROR]', e.message))
-page.on('console', m => { if (m.type() === 'error') console.log('[err]', m.text()) })
 await page.goto(URL)
 await page.waitForTimeout(3000)
 
-// Click the Leva "Walk on planet" button (real user gesture → pointer-lock eligible)
 const btn = page.locator('text=Walk on planet').first()
-const exists = await btn.count()
-console.log('button exists:', exists)
-if (exists > 0) {
-  await btn.click()
-  await page.waitForTimeout(600)
-}
+await btn.click()
+await page.waitForTimeout(500)
 
 let state = await page.evaluate(() => window.__planet.getState().cameraMode)
-console.log('cameraMode after button click:', state)
+console.log('cameraMode after click:', state)
 
-await page.screenshot({ path: '/tmp/rubics-test/walk-after-click.png' })
+const canvas = await page.evaluate(() => {
+  const cs = Array.from(document.querySelectorAll('canvas'))
+  let best = cs[0], bestArea = 0
+  for (const c of cs) {
+    const r = c.getBoundingClientRect()
+    const a = r.width * r.height
+    if (a > bestArea) { bestArea = a; best = c }
+  }
+  const r = best.getBoundingClientRect()
+  return { x: r.x, y: r.y, w: r.width, h: r.height }
+})
+const cx = canvas.x + canvas.w / 2
+const cy = canvas.y + canvas.h / 2
 
-// Simulate walking with WASD
+// Snapshot before mouse-look
+await page.screenshot({ path: '/tmp/rubics-test/walk-mlook-0.png' })
+
+// Pan right via mouse-delta (playwright's mouse.move triggers mousemove with
+// populated movementX regardless of pointer lock).
+await page.mouse.move(cx, cy)
+for (let i = 0; i < 10; i++) {
+  await page.mouse.move(cx + 50 + i * 40, cy, { steps: 1 })
+  await page.waitForTimeout(30)
+}
+await page.screenshot({ path: '/tmp/rubics-test/walk-mlook-right.png' })
+
+// Pan up
+await page.mouse.move(cx, cy)
+for (let i = 0; i < 8; i++) {
+  await page.mouse.move(cx, cy - 40 - i * 30, { steps: 1 })
+  await page.waitForTimeout(30)
+}
+await page.screenshot({ path: '/tmp/rubics-test/walk-mlook-up.png' })
+
+// Forward walk
 await page.keyboard.down('w')
 await page.waitForTimeout(1000)
 await page.keyboard.up('w')
-await page.waitForTimeout(200)
-await page.screenshot({ path: '/tmp/rubics-test/walk-after-w.png' })
+await page.screenshot({ path: '/tmp/rubics-test/walk-mlook-after-w.png' })
 
-// Exit via Tab
 await page.keyboard.press('Tab')
 await page.waitForTimeout(400)
-state = await page.evaluate(() => window.__planet.getState().cameraMode)
-console.log('cameraMode after Tab:', state)
-await page.screenshot({ path: '/tmp/rubics-test/walk-after-tab.png' })
-
 console.log('done')
 await browser.close()

--- a/tests/walk-mode.mjs
+++ b/tests/walk-mode.mjs
@@ -1,0 +1,40 @@
+import { chromium } from 'playwright'
+const URL = process.env.URL || 'http://localhost:5176/'
+const browser = await chromium.launch()
+const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } })
+const page = await ctx.newPage()
+page.on('pageerror', e => console.log('[PAGEERROR]', e.message))
+page.on('console', m => { if (m.type() === 'error') console.log('[err]', m.text()) })
+await page.goto(URL)
+await page.waitForTimeout(3000)
+
+// Click the Leva "Walk on planet" button (real user gesture → pointer-lock eligible)
+const btn = page.locator('text=Walk on planet').first()
+const exists = await btn.count()
+console.log('button exists:', exists)
+if (exists > 0) {
+  await btn.click()
+  await page.waitForTimeout(600)
+}
+
+let state = await page.evaluate(() => window.__planet.getState().cameraMode)
+console.log('cameraMode after button click:', state)
+
+await page.screenshot({ path: '/tmp/rubics-test/walk-after-click.png' })
+
+// Simulate walking with WASD
+await page.keyboard.down('w')
+await page.waitForTimeout(1000)
+await page.keyboard.up('w')
+await page.waitForTimeout(200)
+await page.screenshot({ path: '/tmp/rubics-test/walk-after-w.png' })
+
+// Exit via Tab
+await page.keyboard.press('Tab')
+await page.waitForTimeout(400)
+state = await page.evaluate(() => window.__planet.getState().cameraMode)
+console.log('cameraMode after Tab:', state)
+await page.screenshot({ path: '/tmp/rubics-test/walk-after-tab.png' })
+
+console.log('done')
+await browser.close()


### PR DESCRIPTION
## Summary

Drops the camera to ground level for first-person exploration of the diorama. While there, fixes a latent HDRI bug where scene-level intensity/blur/rotation were silently reverted by sibling mounts.

### Walk mode (`src/world/WalkControls.tsx`)

- Click **Walk on planet** (Leva) → camera drops to player height (`PLANET_R + 0.08`) at the orbit camera's current radial direction, forward = previous view projected to tangent plane. Continuous from wherever you were orbiting.
- **Mouse-look**: yaw around surface normal, pitch as a separate scalar clamped to ±86°. No pointer-lock — cursor stays visible so HDRI / Leva / bezier editor remain interactive while walking. Yaw/pitch only fire when `e.target === canvas` so hovering panels doesn't spin the view.
- **WASD** walks in the tangent plane; tangent forward is drift-corrected each frame. Head stays upright relative to the surface normal so the horizon curves underfoot.
- **Tab / Esc** exits → camera pulls back to radius 4 along last-surface-normal so OrbitControls resumes at a comfortable orbit distance.

### Store / gating

- `cameraMode: 'orbit' | 'walk'` in `usePlanet`. `SphereCamera` unmounts OrbitControls during walk so the two don't fight for the camera.
- `Interaction.tsx` gates its pointer + Q/W/E/A/S/D handlers on `cameraMode === 'orbit'` so slice rotation doesn't fire while walking.

### HDRI persistence fix (`src/world/HDRIEnvironment.tsx`)

Tuning HDRI intensity/blur/rotation worked on first tweak, but scene-level values reverted to three.js defaults on walk-mode entry (and on some other sibling mount races). The store kept the right values but the scene went back to `envI=1, bgI=1, blur=0, rotY=0` until the next slider touch.

- Diagnosis harness: `tests/hdri-persist.mjs` snapshots store + scene before/after bezier drag + walk-mode entry.
- Root cause: one of drei `<Environment>` / OrbitControls with `makeDefault` writes scene defaults on mount cycles; store-dep `useEffect` doesn't re-fire because store unchanged.
- Fix: push scene props every frame in `useFrame` instead of reacting to store changes. 6 assignments/frame, idempotent, always wins.

## Test plan

- [x] `tsc -b` clean
- [x] `vite build` clean (1.75 MB → 557 KB gzipped)
- [x] `tests/walk-mode.mjs` — Leva button enters walk mode; WASD + mouse-look work; Tab returns to orbit
- [x] `tests/hdri-persist.mjs` — store + scene in sync across: bezier drag, walk-mode entry, mid-walk slider tweak
- [ ] Manual on deploy URL — walk on planet, verify HDRI sliders feel responsive

## Deferred (flagged, not in scope)

- Auto-enter walk mode when orbit dollies past `minDistance`
- Collision with diorama objects (walls / trees)
- Crosshair or look-direction indicator
- Esc-key behaviour when also exiting HUD overlays