### PR TITLE
Intro cinematic: solved orbit → animated scramble → yield on hover

### DIFF
--- a/.anvi/hetvabhasa.md
+++ b/.anvi/hetvabhasa.md
@@ -61,6 +61,18 @@ _(At every 10th entry: review, prune stale/non-generalizable entries.)_
 **The trap:** You blame z-fighting and bump Y (doesn't fix it because the chord still dips below), or blame clip planes / material flags / depthWrite (all fine). Root fix: add enough `widthSegments` (and `depthSegments` for long z-axis spans) that the shader has vertices to curve. Rule of thumb: ≥ ~8 segments per cube-face-block the mesh spans.
 **REF:** UNGROUNDED — sphere projection shader lives in-project at `src/diorama/TileGrid.tsx:370-413` (the `<project_vertex>` replacement in `patchMaterialForSphere`). Road fix at `src/diorama/buildDiorama.ts:687-697` (`BoxGeometry(BASE_W, 0.025, ROAD_WIDTH, 64, 1, 1)`).
 
+## P2: Sibling-mount race silently resets scene-level state
+**Root cause:** Drei / R3F siblings (`<Environment>` re-mount paths, `<OrbitControls makeDefault>` mount/unmount) write `scene.environmentIntensity`, `scene.backgroundIntensity`, `scene.backgroundBlurriness`, `scene.environmentRotation` etc. to three.js defaults during their own lifecycle. If your push-to-scene lives in a store-dep `useEffect`, it won't re-fire when the store is unchanged — so the scene stays stuck at the reset values until the next user tweak reaches it through the store.
+**Detection signal:** A slider works on first tweak, then silently "reverts" whenever an unrelated thing mounts/unmounts (walk-mode entry, bezier change, etc.). Store still shows the right value; scene shows the wrong one. No console errors. Can only catch it by reading `scene.*` live.
+**The trap:** Expand `useEffect` dependencies hoping to catch the transition (`[scene, cameraMode, ...]`) — but other resets you haven't identified still slip through. Root fix: push scene-level state in `useFrame` (every frame, idempotent) so you always win the race. Cost: a handful of scalar assignments per frame.
+**REF:** UNGROUNDED — canonical instance `src/world/HDRIEnvironment.tsx:48-62` (push moved from `useEffect` to `useFrame`). Diagnosis harness `tests/hdri-persist.mjs` snapshots store + scene across walk-mode entry.
+
+## P3: React Strict Mode + `startedRef` guard = effect silently no-ops
+**Root cause:** In dev, React Strict Mode invokes effects twice: mount → immediate cleanup → re-mount. A top-of-effect guard like `if (startedRef.current) return; startedRef.current = true;` sees `true` on the second mount and early-returns. The first mount's cleanup already aborted its `setTimeout` / subscription, so the intended behaviour never runs.
+**Detection signal:** One-shot timed sequences (intros, cinematics, delayed bootstraps) fail to fire in dev but work in production (where Strict Mode is off). Diagnosable by logging at the top of the effect — you'll see the early-return line fire on the second mount.
+**The trap:** Move the guard ref out of the component (module-level boolean) — but that breaks component remount (route change) and still races HMR. Root fix: don't guard. Let the effect re-run on each mount; rely on cleanup (`clearTimeout`, `unsubscribe`) to abort correctly, plus a store-state gate at the top of the effect (`if (store.introPhase === 'done') return`) for idempotent skip after completion.
+**REF:** UNGROUNDED — canonical instance `src/world/IntroCinematic.tsx:30-38` (Strict-Mode-compatible re-mount pattern).
+
 ### Entry Format (MANDATORY fields)
 
 ```

--- a/.anvi/vyapti.md
+++ b/.anvi/vyapti.md
@@ -97,6 +97,15 @@ _(Each entry must include a `**REF:**` field pointing to a Ground Truth doc.)_
 **Implication:** For any long/wide mesh added to the diorama: segment count along the spanning axis ≥ ~8 per cube-face-block. Applies to future rivers, rail tracks, cable spans, fence runs, etc.
 **REF:** UNGROUNDED — projection shader at `src/diorama/TileGrid.tsx:370-413`; canonical instance `src/diorama/buildDiorama.ts:687` (road strip).
 
+### PV2: Scene-Shared State Requires Per-Frame Push
+**Statement:** Wherever multiple libraries / components read-write the same `THREE.Scene` top-level properties (`scene.environment`, `scene.environmentIntensity`, `scene.backgroundIntensity`, `scene.backgroundRotation`, etc.), the authoritative push must run every frame, not inside a store-dep `useEffect`.
+**Causal status:** STRUCTURAL — React effects are invalidation-driven (re-run only when deps change). Scene-state resets from sibling mount paths are not expressible as dep changes in the consumer's deps array, so the effect never re-fires to reassert the correct value.
+**Scope:** Any scene-level uniform or scalar consumed across mount boundaries — drei `<Environment>`, `<OrbitControls makeDefault>`, React-three-fiber's own internals.
+**Breaks when:** The property is component-local (a ref on a specific mesh) rather than scene-wide; no other code writes it; or the store-dep effect covers all reset paths (rare — siblings mount non-deterministically with respect to your deps).
+**Confirmed by:** 2026-04-22 — HDRI intensity/blur/rotation reverted to three defaults on walk-mode entry despite the store holding the right values; `tests/hdri-persist.mjs` snapshots confirmed scene drift without store change. Fix: moved push to `useFrame` in `HDRIEnvironment`.
+**Implication:** For shared scene state, prefer `useFrame` over `useEffect`. Cost is trivial (scalar assignments); robustness gain is total. Add a diagnostic harness that snapshots store + scene to detect divergence when introducing a new shared property.
+**REF:** UNGROUNDED — canonical instance `src/world/HDRIEnvironment.tsx:48-62`.
+
 ### Entry Format (with mandatory REF)
 
 ```

--- a/NEXT_SESSION.md
+++ b/NEXT_SESSION.md
@@ -1,4 +1,4 @@
-# New-session handoff prompt — Rubic's World (end of Day 8 on fix/day6-sphere-polish)
+# New-session handoff prompt — Rubic's World (end of Day 9, intro cinematic merging)
 
 Copy the block below into the next session verbatim.
 
@@ -6,91 +6,107 @@ Copy the block below into the next session verbatim.
 
 We're continuing **Rubic's World** — my solo entry for levelsio's **Vibe Jam 2026**.
 
-**Deadline:** 1 May 2026, 13:37 UTC (~12 days out)
+**Deadline:** 1 May 2026, 13:37 UTC (~9 days out)
 **Live URL:** https://rubicsworld.vercel.app (auto-deploys on `git push origin main`)
 **Repo:** https://github.com/MrityunjayBhardwaj/rubicsworld
-**Local dev:** `npm run dev` → http://localhost:5176 (current; port drifts)
+**Local dev:** `npm run dev` → http://localhost:5176 (port drifts)
 **Working dir:** `/Users/mrityunjaybhardwaj/Documents/projects/RubicsWorld`
 
 ## Canonical docs (read in this order)
 
-1. `PHASE_1.md` — the authoritative 15-day plan, scope, stack, cut order, gates.
+1. `PHASE_1.md` — 15-day plan, scope, stack, cut order, gates.
 2. `THESIS.md` — full game design.
-3. `BLENDER_PIPELINE.md` — end-to-end pipeline: cube-net authoring rules, glTF export, engine integration sketch. Reference when shipping any .glb-based diorama.
-4. Memory: `~/.claude/projects/-Users-mrityunjaybhardwaj-Documents-projects-RubicsWorld/memory/` — `project_architecture_day8.md` is the CURRENT architecture (NOT day6_7), and `feedback_shader_patches.md` documents three hard-earned shader-patching rules.
+3. `BLENDER_PIPELINE.md` — glTF authoring pipeline when we move diorama into a .glb file.
+4. Memory: `~/.claude/projects/-Users-mrityunjaybhardwaj-Documents-projects-RubicsWorld/memory/` — `project_architecture_day9.md` is the CURRENT architecture. Also read `feedback_shader_patches.md`, `feedback_per_frame_scene_push.md`, and `feedback_strict_mode_guard.md` — three hard-earned rules.
+5. `.anvi/` catalogues in the repo — `hetvabhasa.md` has P1 (geometry subdivision), P2 (per-frame scene push), P3 (Strict Mode guard). `vyapti.md` has PV1–PV2.
 
 ## Where we are
 
-Branch: `fix/day6-sphere-polish` — ~30+ commits ahead of `main`, still unmerged. PR is overdue; a lot of Day 7–8 work piled on.
+All Day 6–9 work is either merged to main or in review. PRs shipped today:
+- PR #8 — Day 6–8 bundle (sphere pipeline, cross cube-net, diorama content, HDRI panel, PBR)
+- PR #9 — Rotation affordance (keyboard input + yellow-line HUD + easy-mode hints)
+- PR #10 — Walk mode (first-person + HDRI per-frame-push fix)
+- PR #11 — **Intro cinematic** (open at time of writing — solved orbit → scramble → yield on hover)
 
-### Day 6–7 work (from previous handoff, already shipped locally)
-- Sphere pipeline (drag + anim + postfx via FBO + quad, commit-pop fix via tile.orientation).
-- VS-style `isSolved`; `solveAnimated` via history replay.
-- Cross cube-net layout (8×6 bounding box, 24 filled cells).
-- HDRI IBL (drei `<Environment>`) + upload panel; TrackballControls.
-- Per-face labels (A1..F4), v-axis flip at source, cube-view row-swap balanced with sphere's `tileToHome`.
+Current main is always deployable.
 
-### Day 8 work (new since last handoff — all shipped locally on this branch)
-- **Global sphere terrain**: replaced per-tile flat terrain in sphere mode with a single `SphereGeometry(1, 96, 64)` mesh rendered once per frame to the FBO, with triplanar grass sampling. Zero across-face seams (one mesh, no rasterization gap at curved cube edges).
-- **Per-tile texture rotation persistence**: `sliceRotUniforms` now drives (a) an in-shader slice inverse-rotation for fragments in the active slice during animation and (b) a per-tile orientation array `uTileOriInv: Float32Array(24*4)` so texture stays painted on each tile across commits. Indexed by `face*4 + v*2 + u`. Requires `v = (dot(P, fUp) > 0) ? 0 : 1` (INVERTED — `vOff = (0.5 - v)*CELL`).
-- **Idempotent shader patchers**: all three `onBeforeCompile` wrappers (`patchMaterialForFresnel`, `patchMaterialForTriplanar`, `patchMaterialForSphere`) guard against re-entry via `material.userData.__*Patched`. CRITICAL — shared materials (starling flock reuses one across 30 meshes) were silently failing to compile before. READ `feedback_shader_patches.md` before touching any shader patch.
-- **PBR pass**: `mat()` defaults `metalness: 0, roughness: 0.85`; pond corrected to `metalness: 0, roughness: 0.05`; all missing roughness values filled in.
-- **Normal bug fix** in sphere vertex shader: `mat3(viewMatrix) * sphereNormal` (was `normalMatrix * sphereNormal` which treats world-space normal as object-space → garbage).
-- **HDRI Uniform preset**: 256×128 equirect CanvasTexture + auto-PMREM (4×2 is too small and produces degenerate PMREM → black). Color picker UI exposed when preset === 'uniform'.
-- **Fresnel toggle** + **Env × mat** + **Rough+** sliders — live per-material knobs. Base roughness cached in `userData.__baseRoughness` so boost is additive.
-- **Diorama content authored**: hut relocated to `(-1, 0, +0.5)` (upper row of E) to clear road, driveway stone path re-routed; black asphalt **road** spanning `x ∈ [-4, +4]` at `z = -0.5`, with `BRIDGE` at `x ∈ [-0.35, +0.35]` on raised deck; red low-poly **car** animating around the equator with correct ramp pitch; **two starling flocks** (6 birds each) doing all-to-all attractor boids that merge into one cohesive flock — tight formation, shared heading, obstacle avoidance around hut/windmill/well/bridge/trees.
-- **Camera**: reverted sphere from TrackballControls → OrbitControls (polar lock feels more natural for grounded planet sim). `key={...}` forces remount on view change; `makeDefault`; preview `maxDistance` bumped to 60.
-- **BLENDER_PIPELINE.md** written — end-to-end workflow for authoring diorama in Blender (cube-net constraints, materials, naming conventions, glTF export settings, engine integration sketch with GLTFLoader).
+### Day 9 work (all shipped or in PR)
 
-## 🔴 FIRST TASK — road asphalt invisible on sphere
+- **Keyboard rotation hybrid** — hover a tile + Q/W/E/A/S/D. Face-local axes; same `rotateAnimated` pipeline as drag.
+- **Yellow line HUD** on terrain. Thin lines at cube face-boundary edges (cosmetic — within-cubie seams). Thick lines at face-internal seams (the three slice-shear great circles). Corner-fade suppresses 3-face-junction speckle. Global attract-opacity covers the planet at t=0, fades to cursor-reactive after first commit.
+- **Easy-mode correctness colors** — Leva toggle. Lines tint green (both tiles at home) or red (misplaced). Driven by `uHudTileEdgeMask[24]` computed each frame via static `NEIGHBOR_IDX`.
+- **Walk mode** (`WalkControls.tsx`) — click "Walk on planet". First-person camera on surface, mouse-look + WASD. `fwdRef` is tangent-plane, `pitchRef` is a separate scalar (clamped ±86°) so drift-correction doesn't wipe pitch. No pointer-lock → HDRI/Leva panels remain interactive while walking. Tab/Esc exits, camera pulls back to radius 4.
+- **HDRI scene-property push moved to `useFrame`** — fixes silent revert whenever drei `<Environment>` or `<OrbitControls makeDefault>` writes scene defaults during sibling mount. See `feedback_per_frame_scene_push.md`.
+- **Intro cinematic** (`IntroCinematic.tsx`) — on every page load: 2.8 s solved-planet hold with auto-orbit → animated scramble (18 moves) → continued auto-orbit of the scrambled state → first hover/drag/key/walk hands off control. Store now starts with `buildSolvedTiles()` + empty history; intro drives the first scramble.
 
-The black asphalt strip is **not visible in sphere mode** even though the yellow dashes (at `y = ROAD_Y + 0.018`), car, bridge, posts, and ramps all render fine. Earlier this session I bumped `ROAD_Y` from `0.015` → `0.045` thinking it was Z-fighting with the global SphereGeometry terrain at radius 1.0, but **the fix didn't work** — asphalt is still invisible. Need deeper investigation.
+## 🔴 FIRST TASK — once PR #11 is merged
 
-Hypotheses to check:
-1. Z-fighting isn't fixed — need even higher `ROAD_Y` or an explicit `renderOrder` / `polygonOffset`.
-2. Face-boundary clip planes (the 4 planes `n±r`, `n±u`) may be cutting the raised road box where its corners extend into the adjacent face's pyramid. Thin box × raised Y makes this more likely.
-3. Sphere shader vertex projection is collapsing the top/bottom of the thin box to the same sphere radius — the box would be invisible because it's a zero-thickness slab after projection. Check `curvedH` behaviour for very small `rawHeight`.
-4. Material's `side` or `depthTest`/`depthWrite` flags got nuked by one of the patches.
+Pick one:
 
-Good starting point: set `ROAD_Y = 0.15` (much higher — same as bridge's approach height) and see if it becomes visible. If yes, narrows to z-fighting or bezier-curve collapse. If no, the clip planes or material are the culprit.
+### Option A — Audio pass (recommended)
+Howler is in deps, nothing wired. Big atmospheric return per hour:
+1. **Ambient loop** — soft low drone or nature-ish bed under the planet. Volume low, loops seamlessly.
+2. **Slice rotation clicks** — short hollow-wood click on each `rotateAnimated` start or commit. Pitch-vary per axis so the ear learns which axis rotated.
+3. **Settle chime** — single tone on `planet:settled` event (already dispatched from `store.ts::applyRotation` when solving). Warmth cue layered with the PostFx bloom ramp.
+4. Optional: footstep click in walk mode every ~N units of travel.
 
-Diorama road spec is in `src/diorama/buildDiorama.ts` under the "road + car" section.
+Plan it as a `src/world/Audio.tsx` component that subscribes to store events. Keep all samples under 50 KB so they don't blow the bundle further.
 
-## Other open items (after road is fixed)
+### Option B — Walk-mode polish
+1. **Auto-enter walk on orbit zoom-past-minDistance** — per original spec. Watch camera distance; when it dollies to the `minDistance` boundary, flip `cameraMode = 'walk'`.
+2. **Crosshair** — tiny HTML overlay at screen centre while walking. Helps aim when interacting with things.
+3. **Collision with diorama objects** — basic radial push-back from hut/windmill/trees/well/bridge. Reuse the `FLOCK_OBSTACLES` list in `buildDiorama.ts`.
+4. **Orient WASD by look-direction** — currently walks along tangent forward; could feel more natural if walk-direction follows the pitched look instead (on ground, same thing; on slopes, different).
 
-1. **Branch still unmerged** — ~30+ commits on `fix/day6-sphere-polish`. Ship the PR after the road fix.
-2. **Day 7 walk mode** (biggest remaining feature per `PHASE_1.md`).
-3. **Audio pass** — Howler in deps, nothing wired.
-4. **Intro/first-60s framing** — game doesn't teach what to do.
-5. **Cap/fill at clip boundaries** — still unresolved (Option 3 single-pass terrain handled it for terrain but objects still show thin seams where they straddle face edges).
-6. **Visual cues for "this is a puzzle you can grab"** — discussed but not built. Best pick: per-tile biomes (~make scramble visibly wrong) + cursor-proximate face glow + tilt-on-load.
+### Option C — Bundle size
+1.75 MB → 556 KB gzipped. Vite flags >500 KB. Easy wins: code-split drei's Environment helpers, lazy-load PostFx, chunk three.js. Own phase; non-blocking.
+
+### Option D — Per-tile biomes
+The HUD's hard-mode correctness signal requires visually-distinct content per face (desert/ice/forest etc.). Big content pass. Probably post-jam.
+
+## Other open items
+
+1. **Bundle > 500 KB warning** — see Option C.
+2. **Mobile/touch** — walk mode is desktop-only. Phone tap-and-drag to rotate works (pointer events), but no walk fallback. Flag for post-jam if judges complain.
+3. **Starlings occasionally appear as pink dots near HDRI sunset** — their white base material + warm HDRI. Cosmetic, low priority.
+4. **3-face corner speckle in HUD** — `cornerFade` smoothstep already mitigates, but not fully eliminated at extreme zoom. Polish-phase fix.
+5. **Intro replay on reload** — currently plays every time. If that feels stale after a few playthroughs, gate on localStorage (`introSeen`).
+6. **OrbitControls `autoRotate` keeps going after intro ends** (actually it doesn't — `SphereCamera` gates `autoRotate={introPhase !== 'done'}`). No action needed, just a verified invariant.
 
 ## Hard invariants (don't change without asking)
 
-- **`includeTerrain: mode !== 'sphere'`** — sphere mode relies on the global `SphereGeometry` terrain; putting per-tile terrain back reintroduces across-face seams.
-- **Idempotent `onBeforeCompile` patchers** — shared materials break silently without the `__*Patched` guard.
-- **`uTileOriInv` is a `Float32Array(96)`, not `Vector4[]`** — three.js's Vector4-array upload path doesn't reliably propagate updates.
-- **Slice uniforms + orientation array written BEFORE `gl.render(terrainScene, camera)`** in `TileGrid.useFrame` — otherwise terrain is one frame stale, snapping back on commit.
-- **`v = (dot(P, fUp) > 0) ? 0 : 1`** in `computeTileIdx` (inverted v) — matches `vOff = (0.5 - v) * CELL`.
-- **Sphere shader normal fix**: `mat3(viewMatrix) * sphereNormal` (NOT `normalMatrix`).
-- **Cross cube-net layout** — 2×3 rectangular layouts can't fold cleanly.
-- **Road/bridge/car live in per-tile diorama (`buildDiorama` root)**, so they rotate with their tiles. Flock lives there too.
-- Earlier Day 4 invariants still apply: drag-direction picks axis, ring only during drag/anim, 6.5° commit threshold, 2×2 topology.
+**From Day 8** (still live):
+- `includeTerrain: mode !== 'sphere'` — sphere mode uses the global SphereGeometry terrain; per-tile terrain reintroduces seams.
+- Idempotent `onBeforeCompile` patchers — shared materials break silently without the `__*Patched` guard.
+- `uTileOriInv` is `Float32Array(96)`, not `Vector4[]`.
+- Slice uniforms + orientation array written BEFORE `gl.render(terrainScene, camera)` in `TileGrid.useFrame`.
+- `v = (dot(P, fUp) > 0) ? 0 : 1` — inverted v convention in `computeTileIdx`.
+- Sphere shader normal fix: `mat3(viewMatrix) * sphereNormal`, NOT `normalMatrix`.
+- Cross cube-net layout — rectangular 2×3 can't fold cleanly.
+- Road subdivided to 64 widthSegments — unsubdivided long boxes chord through the sphere.
+- Drag-direction picks axis, ring-hidden-by-default, 6.5° commit threshold, 2×2 topology.
+
+**New in Day 9:**
+- **Scene-shared state pushes every frame**, not in store-dep useEffect. See `HDRIEnvironment.useFrame` and vyapti PV2.
+- **Walk-mode forward is decomposed into tangent `fwd` + scalar `pitch`.** Don't merge them; drift correction on fwd would wipe pitch.
+- **OrbitControls unmounts during walk** — `SphereCamera` returns `null` when `cameraMode === 'walk'`. They can't coexist.
+- **IntroCinematic uses store-state gate, not ref-guard.** Strict Mode double-invoke + `startedRef` silently no-ops timed sequences. See hetvabhasa P3 / `feedback_strict_mode_guard.md`.
+- **Initial tiles are SOLVED** — intro drives the first scramble. Changing this requires an intro rewrite.
 
 ## Working style
 
 - Concise. 1–2 sentences end-of-turn.
-- Brainstorm → option matrix → pick before implementing non-trivial work.
+- Brainstorm → option matrix → pick before non-trivial work.
 - Playwright for anything non-trivial to verify; screenshots to `/tmp/rubics-test/`.
 - Commits: gitmoji + `Problem:` / `Fix:` body, no `Co-Authored-By`.
-- Always-deployable main is a hard rule. Ship this branch before bigger work.
+- Always-deployable main. Ship branches in sequence, not stacked.
 
 ## Start by
 
-1. Read `src/diorama/buildDiorama.ts` "road + car" section (~line 660+).
-2. Read `src/diorama/TileGrid.tsx` per-tile sphere loop (~line 685+) and sphere vertex shader patch (~line 330+).
-3. Debug the invisible asphalt per the 4 hypotheses above — recommend starting with `ROAD_Y = 0.15` as a diagnostic.
-4. After it's fixed: ask the user what next — (a) ship the PR, (b) walk mode, (c) other open items.
+1. Confirm PR #11 is merged and main is synced.
+2. Pick Option A (audio) or B (walk polish) based on how the last playthrough felt.
+3. For A: new branch `feat/audio`, new component `src/world/Audio.tsx` subscribing to store / planet events.
+4. For B: new branch `feat/walk-polish`, extend `WalkControls.tsx` + a new `useCameraDistanceWatcher` in `App.tsx`.
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import * as THREE from 'three'
 import { Ring } from './world/Ring'
 import { Interaction } from './world/Interaction'
 import { WalkControls } from './world/WalkControls'
+import { IntroCinematic } from './world/IntroCinematic'
 import { AiSeed } from './world/AiSeed'
 import { PostFx } from './world/PostFx'
 import { TileLabels, TileLabelsLegend } from './world/TileLabels'
@@ -39,7 +40,9 @@ function SphereCamera() {
   // OrbitControls for third-person orbit around the planet. Unmounted when
   // walk mode is active so it doesn't fight WalkControls for the camera.
   const cameraMode = usePlanet(s => s.cameraMode)
+  const introPhase = usePlanet(s => s.introPhase)
   if (cameraMode === 'walk') return null
+  const autoRotate = introPhase !== 'done'
   return (
     <OrbitControls
       key="sphere"
@@ -50,6 +53,8 @@ function SphereCamera() {
       rotateSpeed={0.8}
       enableDamping
       dampingFactor={0.08}
+      autoRotate={autoRotate}
+      autoRotateSpeed={0.9}
     />
   )
 }
@@ -113,6 +118,7 @@ export default function App() {
             <TileLabels mode="sphere" />
             <PostFx />
             <WalkControls />
+            <IntroCinematic />
           </>
         )}
         {preview ? (

--- a/src/world/IntroCinematic.tsx
+++ b/src/world/IntroCinematic.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from 'react'
+import { usePlanet } from './store'
+
+/**
+ * First-frame cinematic attract sequence.
+ *
+ *   ├── INTRO_HOLD_MS = 2800 ── solved planet slow-orbiting, HUD attract full-on
+ *   │                           (lets the player see the intact world first)
+ *   ├── scrambleAnimated(N) ── animated scramble plays ~380 ms/move × N moves
+ *   ├── orbit-scrambled    ── camera keeps auto-orbiting the scrambled planet
+ *   └── player hovers or interacts → endIntro() → autoRotate off, control yields
+ *
+ * End conditions (any wins):
+ *   • onPlanet flips true (raycast hover from Interaction.tsx)
+ *   • drag begins (begin drag can fire before onPlanet on a click-and-drag)
+ *   • walk mode entered
+ *   • player keyboards a rotation
+ */
+
+const INTRO_HOLD_MS = 2800
+const INTRO_SCRAMBLE_MOVES = 18
+
+export function IntroCinematic() {
+  const scrambleAnimated = usePlanet(s => s.scrambleAnimated)
+  const setIntroPhase = usePlanet(s => s.setIntroPhase)
+
+  useEffect(() => {
+    // If the intro has already been played (store marks it 'done' across HMR
+    // or a state-preserving reload), don't replay.
+    if (usePlanet.getState().introPhase === 'done') return
+
+    let aborted = false
+
+    const tHold = setTimeout(async () => {
+      if (aborted) return
+      if (usePlanet.getState().introPhase === 'done') return
+      setIntroPhase('scrambling')
+      if (usePlanet.getState().introPhase === 'done') return
+      await scrambleAnimated(INTRO_SCRAMBLE_MOVES)
+      if (aborted) return
+      if (usePlanet.getState().introPhase !== 'done') {
+        setIntroPhase('orbit-scrambled')
+      }
+    }, INTRO_HOLD_MS)
+
+    // End the intro on first meaningful engagement.
+    const endIfIntroActive = () => {
+      const phase = usePlanet.getState().introPhase
+      if (phase !== 'done') setIntroPhase('done')
+    }
+
+    // Subscribe directly to store slices via zustand's subscribe API — cheaper
+    // than a React render loop for a one-shot transition.
+    const unsubOnPlanet = usePlanet.subscribe((s, prev) => {
+      if (s.onPlanet && !prev.onPlanet) endIfIntroActive()
+      if (s.drag && !prev.drag) endIfIntroActive()
+      if (s.cameraMode === 'walk' && prev.cameraMode !== 'walk') endIfIntroActive()
+    })
+
+    return () => {
+      aborted = true
+      clearTimeout(tHold)
+      unsubOnPlanet()
+    }
+  }, [scrambleAnimated, setIntroPhase])
+
+  return null
+}

--- a/src/world/store.ts
+++ b/src/world/store.ts
@@ -48,6 +48,13 @@ interface PlanetStore {
    *  'walk'  = first-person on the surface, mouse-look + WASD.
    *  Input gates (slice-rotation keys, drag-to-rotate) check this. */
   cameraMode: 'orbit' | 'walk'
+  /** Attract-mode cinematic on page load. Sequence:
+   *    'orbit-solved'    — solved planet slow-orbits (first 3 s)
+   *    'scrambling'      — animated scramble playing
+   *    'orbit-scrambled' — scramble done, still slow-orbiting, waiting for hover
+   *    'done'            — player engaged; camera + input yield to them
+   *  Auto-orbit is enabled while this is NOT 'done'. */
+  introPhase: 'orbit-solved' | 'scrambling' | 'orbit-scrambled' | 'done'
   commitThreshold: number // radians; drag past this and release → commit
   aiEnabled: boolean
   aiHasFired: boolean // per-playthrough latch; resets on scramble/reset
@@ -60,6 +67,7 @@ interface PlanetStore {
   setHoveredTile: (t: HoveredTile | null) => void
   setEasyMode: (v: boolean) => void
   setCameraMode: (v: 'orbit' | 'walk') => void
+  setIntroPhase: (v: PlanetStore['introPhase']) => void
   setCommitThreshold: (v: number) => void
   setAiEnabled: (v: boolean) => void
   markAiFired: () => void
@@ -92,8 +100,10 @@ function makeScrambledTiles(n: number): { tiles: Tile[]; moves: Move[] } {
   return { tiles, moves }
 }
 
-const INITIAL_SCRAMBLE_MOVES = 20
-const initialScramble = makeScrambledTiles(INITIAL_SCRAMBLE_MOVES)
+// Start in solved state so the intro cinematic can show the intact planet
+// slow-orbiting for ~3 s, then play an animated scramble. IntroCinematic
+// drives that sequence; end-user scramble/reset paths are unchanged.
+const initialTiles = buildSolvedTiles()
 
 let animCounter = 0
 let animResolver: (() => void) | null = null
@@ -120,8 +130,8 @@ function applyRotation(
 }
 
 export const usePlanet = create<PlanetStore>((set, get) => ({
-  tiles: initialScramble.tiles,
-  solved: isSolved(initialScramble.tiles),
+  tiles: initialTiles,
+  solved: true,
   anim: null,
   drag: null,
   showLabels: false,
@@ -131,17 +141,19 @@ export const usePlanet = create<PlanetStore>((set, get) => ({
   hudAttractMode: true,
   easyMode: false,
   cameraMode: 'orbit',
+  introPhase: 'orbit-solved',
   commitThreshold: (6.5 * Math.PI) / 180, // 6.5° — tuned for a light digital feel
   aiEnabled: true,
   aiHasFired: false,
   lastPlayerActionAt: typeof performance !== 'undefined' ? performance.now() : 0,
-  history: initialScramble.moves,
+  history: [],
 
   setShowLabels: v => set({ showLabels: v }),
   setShowRing: v => set({ showRing: v }),
   setOnPlanet: v => set(s => (s.onPlanet === v ? {} : { onPlanet: v })),
   setEasyMode: v => set({ easyMode: v }),
   setCameraMode: v => set(s => (s.cameraMode === v ? {} : { cameraMode: v })),
+  setIntroPhase: v => set(s => (s.introPhase === v ? {} : { introPhase: v })),
   setHoveredTile: t => set(s => {
     // Shallow-equal check to skip store churn on redundant writes (pointermove
     // fires ~60Hz; most samples land on the same tile).

--- a/tests/intro-cinematic.mjs
+++ b/tests/intro-cinematic.mjs
@@ -1,0 +1,54 @@
+import { chromium } from 'playwright'
+const URL = process.env.URL || 'http://localhost:5176/'
+const browser = await chromium.launch()
+const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } })
+const page = await ctx.newPage()
+page.on('pageerror', e => console.log('[PAGEERROR]', e.message))
+await page.goto(URL)
+await page.waitForTimeout(300)
+
+const snap = () => page.evaluate(() => ({
+  phase: window.__planet.getState().introPhase,
+  solved: window.__planet.getState().solved,
+  nMoves: window.__planet.getState().history.length,
+  autoRotating: !!window.__scene,
+}))
+
+console.log('T=0.3s  :', JSON.stringify(await snap()))
+await page.screenshot({ path: '/tmp/rubics-test/intro-0-load.png' })
+
+await page.waitForTimeout(1500)
+console.log('T=1.8s  :', JSON.stringify(await snap()))
+await page.screenshot({ path: '/tmp/rubics-test/intro-1-hold.png' })
+
+await page.waitForTimeout(1500)
+console.log('T=3.3s  :', JSON.stringify(await snap()))
+await page.screenshot({ path: '/tmp/rubics-test/intro-2-scrambling.png' })
+
+await page.waitForTimeout(4000)
+console.log('T=7.3s  :', JSON.stringify(await snap()))
+await page.screenshot({ path: '/tmp/rubics-test/intro-3-scrambled.png' })
+
+await page.waitForTimeout(4000)
+console.log('T=11.3s :', JSON.stringify(await snap()))
+await page.screenshot({ path: '/tmp/rubics-test/intro-4-orbiting.png' })
+
+// Now hover planet → should end
+const r3f = await page.evaluate(() => {
+  const cs = Array.from(document.querySelectorAll('canvas'))
+  let best = cs[0], bestArea = 0
+  for (const c of cs) {
+    const r = c.getBoundingClientRect()
+    const a = r.width * r.height
+    if (a > bestArea) { bestArea = a; best = c }
+  }
+  const r = best.getBoundingClientRect()
+  return { x: r.x, y: r.y, w: r.width, h: r.height }
+})
+await page.mouse.move(r3f.x + r3f.w / 2, r3f.y + r3f.h / 2)
+await page.waitForTimeout(400)
+console.log('T=after hover:', JSON.stringify(await snap()))
+await page.screenshot({ path: '/tmp/rubics-test/intro-5-hovered.png' })
+
+console.log('done')
+await browser.close()


### PR DESCRIPTION
## Summary

Attract sequence on every page load. Teaches the player that this is a puzzle before handing them control.

```
  0 ─── 2.8 s ─── ~10 s ────────── hover/drag/key ───────
  │        │          │              │
  solved   scramble   scrambled      done
  orbit    animation  still orbiting (player takes over)
```

- Start state flipped: `buildSolvedTiles`, `history: []`, `solved: true`. No more initial-scramble at module load.
- `IntroCinematic` component: 2.8 s hold → `scrambleAnimated(18)` → `orbit-scrambled`. zustand `subscribe` watches `onPlanet`, `drag`, `cameraMode === 'walk'` — any one ends the intro.
- `SphereCamera` enables OrbitControls `autoRotate` while `introPhase !== 'done'`.
- No localStorage — plays every load. Judges get the show; returning devs hover to skip instantly.

## Test plan

- [x] `tsc -b` clean
- [x] `vite build` clean
- [x] `tests/intro-cinematic.mjs` — phase transitions at expected times, hover hand-off clean
- [x] Manual in dev — title-screen feel, clean hand-off

## Notes for review

- HUD attract fades naturally during scramble (each `applyRotation` flips `hudAttractMode`). By the end of scramble, HUD is already hover-reactive — good continuity.
- React Strict Mode caught a guard-ref bug mid-development: double-invoke + `startedRef` meant the setTimeout was cleared on cleanup and never rescheduled. Removed the guard; cleanup + rescheduling handles re-mount correctly.

## Next up

- Audio pass (ambient + clicks)
- Walk-mode polish (auto-enter on zoom, collision)
- Bundle split (1.75 MB → code-split drei/three)