### PR TITLE
feat: PostFx Path 1 — pmndrs stack polish + realism-effects (SSGI/SSR/motion blur) infrastructure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "lottie-react": "^2.4.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "realism-effects": "^1.1.2",
         "three": "^0.183.2",
         "zustand": "^5.0.12"
       },
@@ -32,6 +33,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "patch-package": "^8.0.1",
         "playwright": "^1.59.1",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.0",
@@ -2229,6 +2231,13 @@
       "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2370,6 +2379,19 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -2426,6 +2448,56 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2487,6 +2559,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/color-convert": {
@@ -2592,6 +2680,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2626,12 +2732,60 @@
       "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.338",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.338.tgz",
       "integrity": "sha512-KVQQ3xko9/coDX3qXLUEEbqkKT8L+1DyAovrtu0Khtrt9wjSZ+7CZV4GVzxFy9Oe1NbrIU1oVXCwHJruIA1PNg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2931,6 +3085,19 @@
         "node": ">= 10"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2946,6 +3113,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
       }
     },
     "node_modules/flat-cache": {
@@ -2978,6 +3155,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2993,6 +3185,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3001,6 +3203,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-value": {
@@ -3044,6 +3285,26 @@
       "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
       "license": "MIT"
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3052,6 +3313,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hermes-estree": {
@@ -3146,6 +3446,22 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extendable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
@@ -3181,6 +3497,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -3197,6 +3523,26 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -3272,6 +3618,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -3292,6 +3658,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3300,6 +3689,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/leva": {
@@ -3700,6 +4099,16 @@
         "three": ">=0.134.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/merge-value/-/merge-value-1.0.0.tgz",
@@ -3730,6 +4139,33 @@
       "integrity": "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==",
       "license": "MIT"
     },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -3741,6 +4177,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mixin-deep": {
@@ -3815,6 +4261,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3876,6 +4349,49 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/path-exists": {
@@ -4118,6 +4634,16 @@
         }
       }
     },
+    "node_modules/realism-effects": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/realism-effects/-/realism-effects-1.1.2.tgz",
+      "integrity": "sha512-dHI++mxZNYJ/k8UO+TUE/PHiNiZcUSkrNlSEwVT48c4d4PHjSz9sjdkH2QlzbmOaI4wYJEmcc9VzI6BZNgpx1A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "postprocessing": ">=6.30.1",
+        "three": ">=0.148.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4194,6 +4720,24 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -4237,6 +4781,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/source-map-js": {
@@ -4390,6 +4944,29 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/troika-three-text": {
       "version": "0.52.4",
       "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
@@ -4533,6 +5110,16 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -4719,6 +5306,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@react-spring/three": "^10.0.3",
@@ -19,6 +20,7 @@
     "lottie-react": "^2.4.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "realism-effects": "^1.1.2",
     "three": "^0.183.2",
     "zustand": "^5.0.12"
   },
@@ -34,6 +36,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "patch-package": "^8.0.1",
     "playwright": "^1.59.1",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.0",

--- a/patches/realism-effects+1.1.2.patch
+++ b/patches/realism-effects+1.1.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/realism-effects/dist/index.cjs b/node_modules/realism-effects/dist/index.cjs
-index 0b2b336..67eca8a 100644
+index 0b2b336..b73e420 100644
 --- a/node_modules/realism-effects/dist/index.cjs
 +++ b/node_modules/realism-effects/dist/index.cjs
 @@ -190,9 +190,9 @@ class CopyPass extends postprocessing.Pass {
@@ -185,6 +185,15 @@ index 0b2b336..67eca8a 100644
      this.diffuseTexture.minFilter = three.LinearFilter;
      this.diffuseTexture.magFilter = three.LinearFilter;
      this.diffuseTexture.colorSpace = three.SRGBColorSpace;
+@@ -1969,7 +1969,7 @@ class SSGIPass extends postprocessing.Pass {
+ 
+ }
+ 
+-var ssgi_compose = "#define GLSLIFY 1\nuniform sampler2D inputTexture;uniform sampler2D sceneTexture;uniform sampler2D depthTexture;uniform int toneMapping;\n#include <tonemapping_pars_fragment>\n#pragma tonemapping_pars_fragment\nvoid mainImage(const in vec4 inputColor,const in vec2 uv,out vec4 outputColor){vec4 depthTexel=textureLod(depthTexture,uv,0.);vec3 ssgiClr;if(dot(depthTexel.rgb,depthTexel.rgb)==0.){ssgiClr=textureLod(sceneTexture,uv,0.).rgb;}else{ssgiClr=textureLod(inputTexture,uv,0.).rgb;switch(toneMapping){case 1:ssgiClr=LinearToneMapping(ssgiClr);break;case 2:ssgiClr=ReinhardToneMapping(ssgiClr);break;case 3:ssgiClr=OptimizedCineonToneMapping(ssgiClr);break;case 4:ssgiClr=ACESFilmicToneMapping(ssgiClr);break;case 5:ssgiClr=CustomToneMapping(ssgiClr);break;}ssgiClr*=toneMappingExposure;}outputColor=vec4(ssgiClr,1.0);}"; // eslint-disable-line
++var ssgi_compose = "#define GLSLIFY 1\nuniform sampler2D inputTexture;uniform sampler2D sceneTexture;uniform sampler2D depthTexture;uniform int toneMapping;\n#include <tonemapping_pars_fragment>\n#pragma tonemapping_pars_fragment\nvoid mainImage(const in vec4 inputColor,const in vec2 uv,out vec4 outputColor){vec4 depthTexel=textureLod(depthTexture,uv,0.);vec3 ssgiClr;if(dot(depthTexel.rgb,depthTexel.rgb)==0.){ssgiClr=textureLod(sceneTexture,uv,0.).rgb;}else{ssgiClr=textureLod(inputTexture,uv,0.).rgb;switch(toneMapping){case 1:ssgiClr=LinearToneMapping(ssgiClr);break;case 2:ssgiClr=ReinhardToneMapping(ssgiClr);break;case 3:ssgiClr=CineonToneMapping(ssgiClr);break;case 4:ssgiClr=ACESFilmicToneMapping(ssgiClr);break;case 5:ssgiClr=CustomToneMapping(ssgiClr);break;}ssgiClr*=toneMappingExposure;}outputColor=vec4(ssgiClr,1.0);}"; // eslint-disable-line
+ 
+ var denoise_compose = "#define GLSLIFY 1\nvec3 viewNormal=(vec4(normal,0.)*cameraMatrixWorld).xyz;roughness*=roughness;vec3 viewPos=getViewPosition(depth);vec3 viewDir=normalize(viewPos);vec3 T,B;vec3 n=viewNormal;vec3 v=viewDir;vec3 V=(vec4(v,0.)*viewMatrix).xyz;vec3 N=normal;Onb(N,T,B);V=ToLocal(T,B,N,V);vec3 H=SampleGGXVNDF(V,roughness,roughness,0.25,0.25);if(H.z<0.0)H=-H;vec3 l=normalize(reflect(-V,H));l=ToWorld(T,B,N,l);l=(vec4(l,1.)*cameraMatrixWorld).xyz;l=normalize(l);if(dot(viewNormal,l)<0.)l=-l;vec3 h=normalize(v+l);float VoH=max(EPSILON,dot(v,h));VoH=pow(VoH,0.875);vec4 diffuseTexel=textureLod(diffuseTexture,vUv,0.);vec3 diffuse=diffuseTexel.rgb;float metalness=diffuseTexel.a;vec3 f0=mix(vec3(0.04),diffuse,metalness);vec3 F=F_Schlick(f0,VoH);vec3 directLight=textureLod(directLightTexture,vUv,0.).rgb;\n#ifdef ssgi\nvec3 diffuseLightingColor=denoisedColor[0];vec3 diffuseComponent=diffuse*(1.-metalness)*(1.-F)*diffuseLightingColor;vec3 specularLightingColor=denoisedColor[1];vec3 specularComponent=specularLightingColor*F;denoisedColor[0]=diffuseComponent+specularComponent;\n#endif\n#ifdef ssdgi\nvec3 diffuseLightingColor=denoisedColor[0];vec3 diffuseComponent=diffuse*(1.-metalness)*(1.-F)*diffuseLightingColor;denoisedColor[0]=diffuseComponent;\n#endif\n#ifdef ssr\nvec3 specularLightingColor=denoisedColor[0];vec3 specularComponent=specularLightingColor*F;denoisedColor[0]=specularComponent;\n#endif\n#ifdef useDirectLight\ndenoisedColor[0]+=directLight;\n#endif\n"; // eslint-disable-line
+ 
 @@ -2745,18 +2745,18 @@ class VelocityDepthNormalPass extends postprocessing.Pass {
      this._scene = scene;
      this._camera = camera;
@@ -234,7 +243,7 @@ index 0b2b336..67eca8a 100644
      this._scene.background = background;
      this.unsetVelocityDepthNormalMaterialInScene();
 diff --git a/node_modules/realism-effects/dist/index.js b/node_modules/realism-effects/dist/index.js
-index 72e1b70..d3e4e34 100644
+index 72e1b70..8198591 100644
 --- a/node_modules/realism-effects/dist/index.js
 +++ b/node_modules/realism-effects/dist/index.js
 @@ -1,5 +1,5 @@
@@ -427,6 +436,15 @@ index 72e1b70..d3e4e34 100644
      this.diffuseTexture.minFilter = LinearFilter;
      this.diffuseTexture.magFilter = LinearFilter;
      this.diffuseTexture.colorSpace = SRGBColorSpace;
+@@ -1967,7 +1967,7 @@ class SSGIPass extends Pass {
+ 
+ }
+ 
+-var ssgi_compose = "#define GLSLIFY 1\nuniform sampler2D inputTexture;uniform sampler2D sceneTexture;uniform sampler2D depthTexture;uniform int toneMapping;\n#include <tonemapping_pars_fragment>\n#pragma tonemapping_pars_fragment\nvoid mainImage(const in vec4 inputColor,const in vec2 uv,out vec4 outputColor){vec4 depthTexel=textureLod(depthTexture,uv,0.);vec3 ssgiClr;if(dot(depthTexel.rgb,depthTexel.rgb)==0.){ssgiClr=textureLod(sceneTexture,uv,0.).rgb;}else{ssgiClr=textureLod(inputTexture,uv,0.).rgb;switch(toneMapping){case 1:ssgiClr=LinearToneMapping(ssgiClr);break;case 2:ssgiClr=ReinhardToneMapping(ssgiClr);break;case 3:ssgiClr=OptimizedCineonToneMapping(ssgiClr);break;case 4:ssgiClr=ACESFilmicToneMapping(ssgiClr);break;case 5:ssgiClr=CustomToneMapping(ssgiClr);break;}ssgiClr*=toneMappingExposure;}outputColor=vec4(ssgiClr,1.0);}"; // eslint-disable-line
++var ssgi_compose = "#define GLSLIFY 1\nuniform sampler2D inputTexture;uniform sampler2D sceneTexture;uniform sampler2D depthTexture;uniform int toneMapping;\n#include <tonemapping_pars_fragment>\n#pragma tonemapping_pars_fragment\nvoid mainImage(const in vec4 inputColor,const in vec2 uv,out vec4 outputColor){vec4 depthTexel=textureLod(depthTexture,uv,0.);vec3 ssgiClr;if(dot(depthTexel.rgb,depthTexel.rgb)==0.){ssgiClr=textureLod(sceneTexture,uv,0.).rgb;}else{ssgiClr=textureLod(inputTexture,uv,0.).rgb;switch(toneMapping){case 1:ssgiClr=LinearToneMapping(ssgiClr);break;case 2:ssgiClr=ReinhardToneMapping(ssgiClr);break;case 3:ssgiClr=CineonToneMapping(ssgiClr);break;case 4:ssgiClr=ACESFilmicToneMapping(ssgiClr);break;case 5:ssgiClr=CustomToneMapping(ssgiClr);break;}ssgiClr*=toneMappingExposure;}outputColor=vec4(ssgiClr,1.0);}"; // eslint-disable-line
+ 
+ var denoise_compose = "#define GLSLIFY 1\nvec3 viewNormal=(vec4(normal,0.)*cameraMatrixWorld).xyz;roughness*=roughness;vec3 viewPos=getViewPosition(depth);vec3 viewDir=normalize(viewPos);vec3 T,B;vec3 n=viewNormal;vec3 v=viewDir;vec3 V=(vec4(v,0.)*viewMatrix).xyz;vec3 N=normal;Onb(N,T,B);V=ToLocal(T,B,N,V);vec3 H=SampleGGXVNDF(V,roughness,roughness,0.25,0.25);if(H.z<0.0)H=-H;vec3 l=normalize(reflect(-V,H));l=ToWorld(T,B,N,l);l=(vec4(l,1.)*cameraMatrixWorld).xyz;l=normalize(l);if(dot(viewNormal,l)<0.)l=-l;vec3 h=normalize(v+l);float VoH=max(EPSILON,dot(v,h));VoH=pow(VoH,0.875);vec4 diffuseTexel=textureLod(diffuseTexture,vUv,0.);vec3 diffuse=diffuseTexel.rgb;float metalness=diffuseTexel.a;vec3 f0=mix(vec3(0.04),diffuse,metalness);vec3 F=F_Schlick(f0,VoH);vec3 directLight=textureLod(directLightTexture,vUv,0.).rgb;\n#ifdef ssgi\nvec3 diffuseLightingColor=denoisedColor[0];vec3 diffuseComponent=diffuse*(1.-metalness)*(1.-F)*diffuseLightingColor;vec3 specularLightingColor=denoisedColor[1];vec3 specularComponent=specularLightingColor*F;denoisedColor[0]=diffuseComponent+specularComponent;\n#endif\n#ifdef ssdgi\nvec3 diffuseLightingColor=denoisedColor[0];vec3 diffuseComponent=diffuse*(1.-metalness)*(1.-F)*diffuseLightingColor;denoisedColor[0]=diffuseComponent;\n#endif\n#ifdef ssr\nvec3 specularLightingColor=denoisedColor[0];vec3 specularComponent=specularLightingColor*F;denoisedColor[0]=specularComponent;\n#endif\n#ifdef useDirectLight\ndenoisedColor[0]+=directLight;\n#endif\n"; // eslint-disable-line
+ 
 @@ -2743,18 +2743,18 @@ class VelocityDepthNormalPass extends Pass {
      this._scene = scene;
      this._camera = camera;

--- a/patches/realism-effects+1.1.2.patch
+++ b/patches/realism-effects+1.1.2.patch
@@ -1,0 +1,477 @@
+diff --git a/node_modules/realism-effects/dist/index.cjs b/node_modules/realism-effects/dist/index.cjs
+index 0b2b336..67eca8a 100644
+--- a/node_modules/realism-effects/dist/index.cjs
++++ b/node_modules/realism-effects/dist/index.cjs
+@@ -190,9 +190,9 @@ class CopyPass extends postprocessing.Pass {
+   constructor(textureCount = 1) {
+     super("CopyPass");
+     this.needsSwap = false;
+-    this.renderTarget = new three.WebGLMultipleRenderTargets(1, 1, 1, {
++    this.renderTarget = new three.WebGLRenderTarget(1, 1, { count: 1, ...{
+       depthBuffer: false
+-    });
++    } });
+     this.setTextureCount(textureCount);
+   }
+ 
+@@ -238,10 +238,10 @@ class CopyPass extends postprocessing.Pass {
+     for (let i = 0; i < textureCount; i++) {
+       this.fullscreenMaterial.uniforms["inputTexture" + i] = new three.Uniform(null);
+ 
+-      if (i >= this.renderTarget.texture.length) {
+-        const texture = this.renderTarget.texture[0].clone();
++      if (i >= this.renderTarget.textures.length) {
++        const texture = this.renderTarget.textures[0].clone();
+         texture.isRenderTargetTexture = true;
+-        this.renderTarget.texture.push(texture);
++        this.renderTarget.textures.push(texture);
+       }
+     }
+   }
+@@ -399,13 +399,13 @@ class TemporalReprojectPass extends postprocessing.Pass {
+     options = { ...defaultTemporalReprojectPassOptions,
+       ...options
+     };
+-    this.renderTarget = new three.WebGLMultipleRenderTargets(1, 1, textureCount, {
++    this.renderTarget = new three.WebGLRenderTarget(1, 1, { count: textureCount, ...{
+       minFilter: three.LinearFilter,
+       magFilter: three.LinearFilter,
+       type: three.HalfFloatType,
+       depthBuffer: false
+-    });
+-    this.renderTarget.texture.map((texture, index) => texture.name = "TemporalReprojectPass.accumulatedTexture" + index);
++    } });
++    this.renderTarget.textures.map((texture, index) => texture.name = "TemporalReprojectPass.accumulatedTexture" + index);
+     this.fullscreenMaterial = new TemporalReprojectMaterial(textureCount, options.temporalReprojectCustomComposeShader);
+     this.fullscreenMaterial.defines.textureCount = textureCount;
+     if (options.dilation) this.fullscreenMaterial.defines.dilation = "";
+@@ -431,7 +431,7 @@ class TemporalReprojectPass extends postprocessing.Pass {
+     this.copyPass = new CopyPass(textureCount);
+ 
+     for (let i = 0; i < textureCount; i++) {
+-      const accumulatedTexture = this.copyPass.renderTarget.texture[i];
++      const accumulatedTexture = this.copyPass.renderTarget.textures[i];
+       accumulatedTexture.type = three.HalfFloatType;
+       accumulatedTexture.minFilter = three.LinearFilter;
+       accumulatedTexture.magFilter = three.LinearFilter;
+@@ -476,7 +476,7 @@ class TemporalReprojectPass extends postprocessing.Pass {
+   }
+ 
+   get texture() {
+-    return this.renderTarget.texture[0];
++    return this.renderTarget.textures[0];
+   }
+ 
+   reset() {
+@@ -506,8 +506,8 @@ class TemporalReprojectPass extends postprocessing.Pass {
+     this.fullscreenMaterial.uniforms.reset.value = false;
+ 
+     for (let i = 0; i < this.textureCount; i++) {
+-      this.copyPass.fullscreenMaterial.uniforms["inputTexture" + i].value = this.renderTarget.texture[i];
+-      this.fullscreenMaterial.uniforms["accumulatedTexture" + i].value = this.copyPass.renderTarget.texture[i];
++      this.copyPass.fullscreenMaterial.uniforms["inputTexture" + i].value = this.renderTarget.textures[i];
++      this.fullscreenMaterial.uniforms["accumulatedTexture" + i].value = this.copyPass.renderTarget.textures[i];
+     }
+ 
+     this.copyPass.render(renderer); // save last transformations
+@@ -681,8 +681,8 @@ class DenoisePass extends postprocessing.Pass {
+       type: three.HalfFloatType,
+       depthBuffer: false
+     };
+-    this.renderTargetA = new three.WebGLMultipleRenderTargets(1, 1, textures.length, renderTargetOptions);
+-    this.renderTargetB = new three.WebGLMultipleRenderTargets(1, 1, textures.length, renderTargetOptions);
++    this.renderTargetA = new three.WebGLRenderTarget(1, 1, { count: textures.length, ...renderTargetOptions });
++    this.renderTargetB = new three.WebGLRenderTarget(1, 1, { count: textures.length, ...renderTargetOptions });
+     if (typeof options.roughnessDependent === "boolean") options.roughnessDependent = Array(textures.length).fill(options.roughnessDependent);
+     this.fullscreenMaterial.defines.roughnessDependent =
+     /* glsl */
+@@ -808,7 +808,7 @@ class DenoisePass extends postprocessing.Pass {
+         const renderTarget = horizontal ? this.renderTargetA : this.renderTargetB;
+ 
+         for (let j = 0; j < this.textures.length; j++) {
+-          this.fullscreenMaterial.uniforms["inputTexture" + j].value = horizontal ? i === 0 ? this.textures[j] : this.renderTargetB.texture[j] : this.renderTargetA.texture[j];
++          this.fullscreenMaterial.uniforms["inputTexture" + j].value = horizontal ? i === 0 ? this.textures[j] : this.renderTargetB.textures[j] : this.renderTargetA.textures[j];
+         }
+ 
+         renderer.setRenderTarget(renderTarget);
+@@ -833,7 +833,7 @@ class DenoisePass extends postprocessing.Pass {
+ 
+ 
+   get texture() {
+-    return this.renderTargetB.texture[0];
++    return this.renderTargetB.textures[0];
+   }
+ 
+ }
+@@ -852,13 +852,13 @@ class SVGFTemporalReprojectPass extends TemporalReprojectPass {
+     };
+     super(scene, camera, velocityDepthNormalPass, textureCount, options); // moment
+ 
+-    this.momentTexture = this.renderTarget.texture[0].clone();
++    this.momentTexture = this.renderTarget.textures[0].clone();
+     this.momentTexture.isRenderTargetTexture = true;
+     this.momentTexture.type = three.FloatType;
+     this.momentTexture.minFilter = three.NearestFilter;
+     this.momentTexture.magFilter = three.NearestFilter;
+     this.momentTexture.needsUpdate = true;
+-    this.renderTarget.texture.push(this.momentTexture);
++    this.renderTarget.textures.push(this.momentTexture);
+     const momentBuffers =
+     /* glsl */
+     `
+@@ -875,7 +875,7 @@ class SVGFTemporalReprojectPass extends TemporalReprojectPass {
+     const copyPassTextureCount = textureCount + 1;
+     this.copyPass.setTextureCount(copyPassTextureCount);
+     this.copyPass.fullscreenMaterial.uniforms["inputTexture" + (copyPassTextureCount - 1)].value = this.momentTexture;
+-    const lastMomentTexture = this.copyPass.renderTarget.texture[copyPassTextureCount - 1];
++    const lastMomentTexture = this.copyPass.renderTarget.textures[copyPassTextureCount - 1];
+     lastMomentTexture.type = three.FloatType;
+     lastMomentTexture.minFilter = three.LinearFilter; // need to use linear filter over nearest filter
+ 
+@@ -890,7 +890,7 @@ class SVGFTemporalReprojectPass extends TemporalReprojectPass {
+ class SVGF {
+   constructor(scene, camera, velocityDepthNormalPass, textureCount = 1, options = {}) {
+     this.svgfTemporalReprojectPass = new SVGFTemporalReprojectPass(scene, camera, velocityDepthNormalPass, textureCount, options);
+-    const textures = this.svgfTemporalReprojectPass.renderTarget.texture.slice(0, textureCount);
++    const textures = this.svgfTemporalReprojectPass.renderTarget.textures.slice(0, textureCount);
+     this.denoisePass = new DenoisePass(camera, textures, options);
+     this.denoisePass.setMomentTexture(this.svgfTemporalReprojectPass.momentTexture);
+     this.setNonJitteredDepthTexture(velocityDepthNormalPass.depthTexture);
+@@ -1779,10 +1779,10 @@ class SSGIPass extends postprocessing.Pass {
+     this.fullscreenMaterial = new SSGIMaterial();
+     this.defaultFragmentShader = this.fullscreenMaterial.fragmentShader;
+     const bufferCount = !options.diffuseOnly && !options.specularOnly ? 2 : 1;
+-    this.renderTarget = new three.WebGLMultipleRenderTargets(1, 1, bufferCount, {
++    this.renderTarget = new three.WebGLRenderTarget(1, 1, { count: bufferCount, ...{
+       type: three.HalfFloatType,
+       depthBuffer: false
+-    }); // set up basic uniforms that we don't have to update
++    } }); // set up basic uniforms that we don't have to update
+ 
+     this.fullscreenMaterial.uniforms.cameraMatrixWorld.value = this._camera.matrixWorld;
+     this.fullscreenMaterial.uniforms.viewMatrix.value = this._camera.matrixWorldInverse;
+@@ -1807,26 +1807,26 @@ class SSGIPass extends postprocessing.Pass {
+   }
+ 
+   get texture() {
+-    return this.renderTarget.texture[0];
++    return this.renderTarget.textures[0];
+   }
+ 
+   get specularTexture() {
+     const index = "specularOnly" in this.fullscreenMaterial.defines ? 0 : 1;
+-    return this.renderTarget.texture[index];
++    return this.renderTarget.textures[index];
+   }
+ 
+   initMRTRenderTarget() {
+-    this.gBuffersRenderTarget = new three.WebGLMultipleRenderTargets(1, 1, 4, {
++    this.gBuffersRenderTarget = new three.WebGLRenderTarget(1, 1, { count: 4, ...{
+       minFilter: three.NearestFilter,
+       magFilter: three.NearestFilter
+-    });
++    } });
+     this.gBuffersRenderTarget.depthTexture = new three.DepthTexture(1, 1);
+     this.gBuffersRenderTarget.depthTexture.type = three.FloatType;
+     this.backSideDepthPass = new BackSideDepthPass(this._scene, this._camera);
+-    this.depthTexture = this.gBuffersRenderTarget.texture[0];
+-    this.normalTexture = this.gBuffersRenderTarget.texture[1];
+-    this.diffuseTexture = this.gBuffersRenderTarget.texture[2];
+-    this.emissiveTexture = this.gBuffersRenderTarget.texture[3];
++    this.depthTexture = this.gBuffersRenderTarget.textures[0];
++    this.normalTexture = this.gBuffersRenderTarget.textures[1];
++    this.diffuseTexture = this.gBuffersRenderTarget.textures[2];
++    this.emissiveTexture = this.gBuffersRenderTarget.textures[3];
+     this.diffuseTexture.minFilter = three.LinearFilter;
+     this.diffuseTexture.magFilter = three.LinearFilter;
+     this.diffuseTexture.colorSpace = three.SRGBColorSpace;
+@@ -2745,18 +2745,18 @@ class VelocityDepthNormalPass extends postprocessing.Pass {
+     this._scene = scene;
+     this._camera = camera;
+     const bufferCount = renderDepth ? 2 : 1;
+-    this.renderTarget = new three.WebGLMultipleRenderTargets(1, 1, bufferCount, {
++    this.renderTarget = new three.WebGLRenderTarget(1, 1, { count: bufferCount, ...{
+       minFilter: three.NearestFilter,
+       magFilter: three.NearestFilter
+-    });
++    } });
+     this.renderTarget.depthTexture = new three.DepthTexture(1, 1);
+     this.renderTarget.depthTexture.type = three.FloatType;
+ 
+     if (renderDepth) {
+-      this.renderTarget.texture[0].type = three.UnsignedByteType;
+-      this.renderTarget.texture[0].needsUpdate = true;
+-      this.renderTarget.texture[1].type = three.FloatType;
+-      this.renderTarget.texture[1].needsUpdate = true;
++      this.renderTarget.textures[0].type = three.UnsignedByteType;
++      this.renderTarget.textures[0].needsUpdate = true;
++      this.renderTarget.textures[1].type = three.FloatType;
++      this.renderTarget.textures[1].needsUpdate = true;
+     }
+ 
+     this.renderDepth = renderDepth;
+@@ -2812,11 +2812,11 @@ class VelocityDepthNormalPass extends postprocessing.Pass {
+   }
+ 
+   get texture() {
+-    return Array.isArray(this.renderTarget.texture) ? this.renderTarget.texture[1] : this.renderTarget.texture;
++    return (this.renderTarget.textures && this.renderTarget.textures.length > 1) ? this.renderTarget.textures[1] : this.renderTarget.texture;
+   }
+ 
+   get depthTexture() {
+-    return this.renderTarget.texture[0];
++    return this.renderTarget.textures[0];
+   }
+ 
+   render(renderer) {
+@@ -2835,7 +2835,7 @@ class VelocityDepthNormalPass extends postprocessing.Pass {
+     } = this._scene;
+     this._scene.background = backgroundColor;
+     renderer.setRenderTarget(this.renderTarget);
+-    renderer.copyFramebufferToTexture(zeroVec2, this.lastDepthTexture);
++    renderer.copyFramebufferToTexture(this.lastDepthTexture, zeroVec2);
+     renderer.render(this._scene, this._camera);
+     this._scene.background = background;
+     this.unsetVelocityDepthNormalMaterialInScene();
+diff --git a/node_modules/realism-effects/dist/index.js b/node_modules/realism-effects/dist/index.js
+index 72e1b70..d3e4e34 100644
+--- a/node_modules/realism-effects/dist/index.js
++++ b/node_modules/realism-effects/dist/index.js
+@@ -1,5 +1,5 @@
+ import { Pass, Effect, RenderPass, Selection, NormalPass } from 'postprocessing';
+-import { DataTexture, RGBAFormat, FloatType, ShaderChunk, ShaderLib, UniformsUtils, WebGLMultipleRenderTargets, ShaderMaterial, GLSL3, NoBlending, Uniform, Vector2, Matrix4, Vector3, Clock, Quaternion, LinearFilter, HalfFloatType, UnsignedByteType, RGBADepthPacking, BasicDepthPacking, NearestFilter, WebGLRenderTarget, ClampToEdgeWrapping, LinearMipMapLinearFilter, EquirectangularReflectionMapping, Color, Matrix3, TangentSpaceNormalMap, RepeatWrapping, RedFormat, Source, MeshDepthMaterial, BackSide, TextureLoader, NoColorSpace, DepthTexture, SRGBColorSpace, Texture, NoToneMapping, PerspectiveCamera, FramebufferTexture } from 'three';
++import { DataTexture, RGBAFormat, FloatType, ShaderChunk, ShaderLib, UniformsUtils, ShaderMaterial, GLSL3, NoBlending, Uniform, Vector2, Matrix4, Vector3, Clock, Quaternion, LinearFilter, HalfFloatType, UnsignedByteType, RGBADepthPacking, BasicDepthPacking, NearestFilter, WebGLRenderTarget, ClampToEdgeWrapping, LinearMipMapLinearFilter, EquirectangularReflectionMapping, Color, Matrix3, TangentSpaceNormalMap, RepeatWrapping, RedFormat, Source, MeshDepthMaterial, BackSide, TextureLoader, NoColorSpace, DepthTexture, SRGBColorSpace, Texture, NoToneMapping, PerspectiveCamera, FramebufferTexture } from 'three';
+ 
+ const getVisibleChildren = object => {
+   const queue = [object];
+@@ -188,9 +188,9 @@ class CopyPass extends Pass {
+   constructor(textureCount = 1) {
+     super("CopyPass");
+     this.needsSwap = false;
+-    this.renderTarget = new WebGLMultipleRenderTargets(1, 1, 1, {
++    this.renderTarget = new WebGLRenderTarget(1, 1, { count: 1, ...{
+       depthBuffer: false
+-    });
++    } });
+     this.setTextureCount(textureCount);
+   }
+ 
+@@ -236,10 +236,10 @@ class CopyPass extends Pass {
+     for (let i = 0; i < textureCount; i++) {
+       this.fullscreenMaterial.uniforms["inputTexture" + i] = new Uniform(null);
+ 
+-      if (i >= this.renderTarget.texture.length) {
+-        const texture = this.renderTarget.texture[0].clone();
++      if (i >= this.renderTarget.textures.length) {
++        const texture = this.renderTarget.textures[0].clone();
+         texture.isRenderTargetTexture = true;
+-        this.renderTarget.texture.push(texture);
++        this.renderTarget.textures.push(texture);
+       }
+     }
+   }
+@@ -397,13 +397,13 @@ class TemporalReprojectPass extends Pass {
+     options = { ...defaultTemporalReprojectPassOptions,
+       ...options
+     };
+-    this.renderTarget = new WebGLMultipleRenderTargets(1, 1, textureCount, {
++    this.renderTarget = new WebGLRenderTarget(1, 1, { count: textureCount, ...{
+       minFilter: LinearFilter,
+       magFilter: LinearFilter,
+       type: HalfFloatType,
+       depthBuffer: false
+-    });
+-    this.renderTarget.texture.map((texture, index) => texture.name = "TemporalReprojectPass.accumulatedTexture" + index);
++    } });
++    this.renderTarget.textures.map((texture, index) => texture.name = "TemporalReprojectPass.accumulatedTexture" + index);
+     this.fullscreenMaterial = new TemporalReprojectMaterial(textureCount, options.temporalReprojectCustomComposeShader);
+     this.fullscreenMaterial.defines.textureCount = textureCount;
+     if (options.dilation) this.fullscreenMaterial.defines.dilation = "";
+@@ -429,7 +429,7 @@ class TemporalReprojectPass extends Pass {
+     this.copyPass = new CopyPass(textureCount);
+ 
+     for (let i = 0; i < textureCount; i++) {
+-      const accumulatedTexture = this.copyPass.renderTarget.texture[i];
++      const accumulatedTexture = this.copyPass.renderTarget.textures[i];
+       accumulatedTexture.type = HalfFloatType;
+       accumulatedTexture.minFilter = LinearFilter;
+       accumulatedTexture.magFilter = LinearFilter;
+@@ -474,7 +474,7 @@ class TemporalReprojectPass extends Pass {
+   }
+ 
+   get texture() {
+-    return this.renderTarget.texture[0];
++    return this.renderTarget.textures[0];
+   }
+ 
+   reset() {
+@@ -504,8 +504,8 @@ class TemporalReprojectPass extends Pass {
+     this.fullscreenMaterial.uniforms.reset.value = false;
+ 
+     for (let i = 0; i < this.textureCount; i++) {
+-      this.copyPass.fullscreenMaterial.uniforms["inputTexture" + i].value = this.renderTarget.texture[i];
+-      this.fullscreenMaterial.uniforms["accumulatedTexture" + i].value = this.copyPass.renderTarget.texture[i];
++      this.copyPass.fullscreenMaterial.uniforms["inputTexture" + i].value = this.renderTarget.textures[i];
++      this.fullscreenMaterial.uniforms["accumulatedTexture" + i].value = this.copyPass.renderTarget.textures[i];
+     }
+ 
+     this.copyPass.render(renderer); // save last transformations
+@@ -679,8 +679,8 @@ class DenoisePass extends Pass {
+       type: HalfFloatType,
+       depthBuffer: false
+     };
+-    this.renderTargetA = new WebGLMultipleRenderTargets(1, 1, textures.length, renderTargetOptions);
+-    this.renderTargetB = new WebGLMultipleRenderTargets(1, 1, textures.length, renderTargetOptions);
++    this.renderTargetA = new WebGLRenderTarget(1, 1, { count: textures.length, ...renderTargetOptions });
++    this.renderTargetB = new WebGLRenderTarget(1, 1, { count: textures.length, ...renderTargetOptions });
+     if (typeof options.roughnessDependent === "boolean") options.roughnessDependent = Array(textures.length).fill(options.roughnessDependent);
+     this.fullscreenMaterial.defines.roughnessDependent =
+     /* glsl */
+@@ -806,7 +806,7 @@ class DenoisePass extends Pass {
+         const renderTarget = horizontal ? this.renderTargetA : this.renderTargetB;
+ 
+         for (let j = 0; j < this.textures.length; j++) {
+-          this.fullscreenMaterial.uniforms["inputTexture" + j].value = horizontal ? i === 0 ? this.textures[j] : this.renderTargetB.texture[j] : this.renderTargetA.texture[j];
++          this.fullscreenMaterial.uniforms["inputTexture" + j].value = horizontal ? i === 0 ? this.textures[j] : this.renderTargetB.textures[j] : this.renderTargetA.textures[j];
+         }
+ 
+         renderer.setRenderTarget(renderTarget);
+@@ -831,7 +831,7 @@ class DenoisePass extends Pass {
+ 
+ 
+   get texture() {
+-    return this.renderTargetB.texture[0];
++    return this.renderTargetB.textures[0];
+   }
+ 
+ }
+@@ -850,13 +850,13 @@ class SVGFTemporalReprojectPass extends TemporalReprojectPass {
+     };
+     super(scene, camera, velocityDepthNormalPass, textureCount, options); // moment
+ 
+-    this.momentTexture = this.renderTarget.texture[0].clone();
++    this.momentTexture = this.renderTarget.textures[0].clone();
+     this.momentTexture.isRenderTargetTexture = true;
+     this.momentTexture.type = FloatType;
+     this.momentTexture.minFilter = NearestFilter;
+     this.momentTexture.magFilter = NearestFilter;
+     this.momentTexture.needsUpdate = true;
+-    this.renderTarget.texture.push(this.momentTexture);
++    this.renderTarget.textures.push(this.momentTexture);
+     const momentBuffers =
+     /* glsl */
+     `
+@@ -873,7 +873,7 @@ class SVGFTemporalReprojectPass extends TemporalReprojectPass {
+     const copyPassTextureCount = textureCount + 1;
+     this.copyPass.setTextureCount(copyPassTextureCount);
+     this.copyPass.fullscreenMaterial.uniforms["inputTexture" + (copyPassTextureCount - 1)].value = this.momentTexture;
+-    const lastMomentTexture = this.copyPass.renderTarget.texture[copyPassTextureCount - 1];
++    const lastMomentTexture = this.copyPass.renderTarget.textures[copyPassTextureCount - 1];
+     lastMomentTexture.type = FloatType;
+     lastMomentTexture.minFilter = LinearFilter; // need to use linear filter over nearest filter
+ 
+@@ -888,7 +888,7 @@ class SVGFTemporalReprojectPass extends TemporalReprojectPass {
+ class SVGF {
+   constructor(scene, camera, velocityDepthNormalPass, textureCount = 1, options = {}) {
+     this.svgfTemporalReprojectPass = new SVGFTemporalReprojectPass(scene, camera, velocityDepthNormalPass, textureCount, options);
+-    const textures = this.svgfTemporalReprojectPass.renderTarget.texture.slice(0, textureCount);
++    const textures = this.svgfTemporalReprojectPass.renderTarget.textures.slice(0, textureCount);
+     this.denoisePass = new DenoisePass(camera, textures, options);
+     this.denoisePass.setMomentTexture(this.svgfTemporalReprojectPass.momentTexture);
+     this.setNonJitteredDepthTexture(velocityDepthNormalPass.depthTexture);
+@@ -1777,10 +1777,10 @@ class SSGIPass extends Pass {
+     this.fullscreenMaterial = new SSGIMaterial();
+     this.defaultFragmentShader = this.fullscreenMaterial.fragmentShader;
+     const bufferCount = !options.diffuseOnly && !options.specularOnly ? 2 : 1;
+-    this.renderTarget = new WebGLMultipleRenderTargets(1, 1, bufferCount, {
++    this.renderTarget = new WebGLRenderTarget(1, 1, { count: bufferCount, ...{
+       type: HalfFloatType,
+       depthBuffer: false
+-    }); // set up basic uniforms that we don't have to update
++    } }); // set up basic uniforms that we don't have to update
+ 
+     this.fullscreenMaterial.uniforms.cameraMatrixWorld.value = this._camera.matrixWorld;
+     this.fullscreenMaterial.uniforms.viewMatrix.value = this._camera.matrixWorldInverse;
+@@ -1805,26 +1805,26 @@ class SSGIPass extends Pass {
+   }
+ 
+   get texture() {
+-    return this.renderTarget.texture[0];
++    return this.renderTarget.textures[0];
+   }
+ 
+   get specularTexture() {
+     const index = "specularOnly" in this.fullscreenMaterial.defines ? 0 : 1;
+-    return this.renderTarget.texture[index];
++    return this.renderTarget.textures[index];
+   }
+ 
+   initMRTRenderTarget() {
+-    this.gBuffersRenderTarget = new WebGLMultipleRenderTargets(1, 1, 4, {
++    this.gBuffersRenderTarget = new WebGLRenderTarget(1, 1, { count: 4, ...{
+       minFilter: NearestFilter,
+       magFilter: NearestFilter
+-    });
++    } });
+     this.gBuffersRenderTarget.depthTexture = new DepthTexture(1, 1);
+     this.gBuffersRenderTarget.depthTexture.type = FloatType;
+     this.backSideDepthPass = new BackSideDepthPass(this._scene, this._camera);
+-    this.depthTexture = this.gBuffersRenderTarget.texture[0];
+-    this.normalTexture = this.gBuffersRenderTarget.texture[1];
+-    this.diffuseTexture = this.gBuffersRenderTarget.texture[2];
+-    this.emissiveTexture = this.gBuffersRenderTarget.texture[3];
++    this.depthTexture = this.gBuffersRenderTarget.textures[0];
++    this.normalTexture = this.gBuffersRenderTarget.textures[1];
++    this.diffuseTexture = this.gBuffersRenderTarget.textures[2];
++    this.emissiveTexture = this.gBuffersRenderTarget.textures[3];
+     this.diffuseTexture.minFilter = LinearFilter;
+     this.diffuseTexture.magFilter = LinearFilter;
+     this.diffuseTexture.colorSpace = SRGBColorSpace;
+@@ -2743,18 +2743,18 @@ class VelocityDepthNormalPass extends Pass {
+     this._scene = scene;
+     this._camera = camera;
+     const bufferCount = renderDepth ? 2 : 1;
+-    this.renderTarget = new WebGLMultipleRenderTargets(1, 1, bufferCount, {
++    this.renderTarget = new WebGLRenderTarget(1, 1, { count: bufferCount, ...{
+       minFilter: NearestFilter,
+       magFilter: NearestFilter
+-    });
++    } });
+     this.renderTarget.depthTexture = new DepthTexture(1, 1);
+     this.renderTarget.depthTexture.type = FloatType;
+ 
+     if (renderDepth) {
+-      this.renderTarget.texture[0].type = UnsignedByteType;
+-      this.renderTarget.texture[0].needsUpdate = true;
+-      this.renderTarget.texture[1].type = FloatType;
+-      this.renderTarget.texture[1].needsUpdate = true;
++      this.renderTarget.textures[0].type = UnsignedByteType;
++      this.renderTarget.textures[0].needsUpdate = true;
++      this.renderTarget.textures[1].type = FloatType;
++      this.renderTarget.textures[1].needsUpdate = true;
+     }
+ 
+     this.renderDepth = renderDepth;
+@@ -2810,11 +2810,11 @@ class VelocityDepthNormalPass extends Pass {
+   }
+ 
+   get texture() {
+-    return Array.isArray(this.renderTarget.texture) ? this.renderTarget.texture[1] : this.renderTarget.texture;
++    return (this.renderTarget.textures && this.renderTarget.textures.length > 1) ? this.renderTarget.textures[1] : this.renderTarget.texture;
+   }
+ 
+   get depthTexture() {
+-    return this.renderTarget.texture[0];
++    return this.renderTarget.textures[0];
+   }
+ 
+   render(renderer) {
+@@ -2833,7 +2833,7 @@ class VelocityDepthNormalPass extends Pass {
+     } = this._scene;
+     this._scene.background = backgroundColor;
+     renderer.setRenderTarget(this.renderTarget);
+-    renderer.copyFramebufferToTexture(zeroVec2, this.lastDepthTexture);
++    renderer.copyFramebufferToTexture(this.lastDepthTexture, zeroVec2);
+     renderer.render(this._scene, this._camera);
+     this._scene.background = background;
+     this.unsetVelocityDepthNormalMaterialInScene();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,7 +95,11 @@ export default function App() {
           near: 0.01,
         }}
         shadows={!!preview}
-        gl={{ antialias: true, stencil: true }}
+        // antialias disabled: SMAA runs in the PostFx effect chain instead, so
+        // the effect composer sees crisp edges and so Path 2 (realism-effects
+        // SSGI/TRAA) can later take full control of MSAA. toneMapping moved
+        // to the renderer (ACES Filmic) so effect passes receive linear input.
+        gl={{ antialias: false, stencil: true, toneMapping: THREE.ACESFilmicToneMapping, toneMappingExposure: 1.35 }}
         dpr={[1, 2]}
       >
         <color attach="background" args={['#0a0d12']} />

--- a/src/diorama/TileGrid.tsx
+++ b/src/diorama/TileGrid.tsx
@@ -305,27 +305,14 @@ interface SphereUniforms {
   uFaceNormal: { value: THREE.Vector3 }
   uBezier: { value: THREE.Vector4 }  // (cx1, cy1, cx2, cy2)
   uMaxHeight: { value: number }
-  /** 1.0 = apply sphere projection, 0.0 = render in cube space (debug). */
-  uSphereProjectionEnabled: { value: number }
-}
-
-/**
- * Module-level singleton — shared across every sphere-patched material.
- * Exported so external controls (PostFx Leva) can toggle the projection
- * at runtime for A/B debugging (e.g. to isolate N8AO's dependency on
- * smooth-depth geometry vs our custom vertex displacement).
- */
-export const sphereUniforms: SphereUniforms = {
-  uFaceNormal: { value: new THREE.Vector3(0, 1, 0) },
-  uBezier: { value: new THREE.Vector4(0.25, 0.1, 0.75, 0.9) },
-  uMaxHeight: { value: 1.0 },
-  uSphereProjectionEnabled: { value: 1.0 },
 }
 
 function createSphereUniforms(): SphereUniforms {
-  // Per-mount: reuse the module-level singleton so Leva writes are seen
-  // by every patched material immediately.
-  return sphereUniforms
+  return {
+    uFaceNormal: { value: new THREE.Vector3(0, 1, 0) },
+    uBezier: { value: new THREE.Vector4(0.25, 0.1, 0.75, 0.9) },
+    uMaxHeight: { value: 1.0 },
+  }
 }
 
 function patchMaterialForSphere(material: THREE.Material, uniforms: SphereUniforms) {
@@ -348,15 +335,12 @@ function patchMaterialForSphere(material: THREE.Material, uniforms: SphereUnifor
     shader.uniforms.uBezier = uniforms.uBezier
     shader.uniforms.uMaxHeight = uniforms.uMaxHeight
 
-    shader.uniforms.uSphereProjectionEnabled = uniforms.uSphereProjectionEnabled
-
     shader.vertexShader = shader.vertexShader.replace(
       '#include <common>',
       `#include <common>
       uniform vec3 uFaceNormal;
       uniform vec4 uBezier;    // (cx1, cy1, cx2, cy2)
       uniform float uMaxHeight;
-      uniform float uSphereProjectionEnabled;
 
       // Cubic bezier evaluation
       float cbez(float t, float p0, float p1, float p2, float p3) {
@@ -388,9 +372,7 @@ function patchMaterialForSphere(material: THREE.Material, uniforms: SphereUnifor
       }`,
     )
 
-    // Replace project_vertex with additive sphere projection.
-    // uSphereProjectionEnabled gates the curvature: 1.0 → sphere-project,
-    // 0.0 → cube-space fallback (standard MVP). Debug toggle from PostFx.
+    // Replace project_vertex with additive sphere projection
     shader.vertexShader = shader.vertexShader.replace(
       '#include <project_vertex>',
       `
@@ -399,39 +381,33 @@ function patchMaterialForSphere(material: THREE.Material, uniforms: SphereUnifor
         vClipPosition = -(modelViewMatrix * vec4(transformed, 1.0)).xyz;
       #endif
 
-      vec4 mvPosition;
-      if (uSphereProjectionEnabled > 0.5) {
-        // Sphere projection with bezier height curve
-        vec4 worldPos = modelMatrix * vec4(transformed, 1.0);
-        vec3 wp = worldPos.xyz;
-        float faceDistance = dot(wp, uFaceNormal);
-        float rawHeight = faceDistance - 1.0;
+      // Sphere projection with bezier height curve
+      vec4 worldPos = modelMatrix * vec4(transformed, 1.0);
+      vec3 wp = worldPos.xyz;
+      float faceDistance = dot(wp, uFaceNormal);
+      float rawHeight = faceDistance - 1.0;
 
-        // Apply bezier curve to normalized height
-        float normalizedH = clamp(rawHeight / uMaxHeight, 0.0, 1.0);
-        float curvedH = rawHeight <= 0.0 ? rawHeight : evalHeightCurve(normalizedH) * uMaxHeight;
+      // Apply bezier curve to normalized height
+      float normalizedH = clamp(rawHeight / uMaxHeight, 0.0, 1.0);
+      float curvedH = rawHeight <= 0.0 ? rawHeight : evalHeightCurve(normalizedH) * uMaxHeight;
 
-        vec3 basePoint = wp - rawHeight * uFaceNormal;
-        vec3 sphereBase = normalize(basePoint);
-        vec3 spherePos = sphereBase * (1.0 + curvedH);
+      vec3 basePoint = wp - rawHeight * uFaceNormal;
+      vec3 sphereBase = normalize(basePoint);
+      vec3 spherePos = sphereBase * (1.0 + curvedH);
 
-        // Correct normals for sphere curvature.
-        // sphereNormal is WORLD-space (radial from origin). To land in view
-        // space we apply mat3(viewMatrix), not normalMatrix — the latter
-        // expects object-space input and would yield a garbage direction,
-        // corrupting N·V and therefore Fresnel on ground geometry.
-        #ifdef USE_NORMAL
-          vec3 sphereNormal = normalize(sphereBase);
-          // Ground-level geometry follows the sphere, tall objects keep their own normals.
-          float normalBlend = clamp(1.0 - normalizedH * 2.0, 0.0, 1.0);
-          vNormal = normalize(mix(vNormal, mat3(viewMatrix) * sphereNormal, normalBlend));
-        #endif
+      // Correct normals for sphere curvature.
+      // sphereNormal is WORLD-space (radial from origin). To land in view
+      // space we apply mat3(viewMatrix), not normalMatrix — the latter
+      // expects object-space input and would yield a garbage direction,
+      // corrupting N·V and therefore Fresnel on ground geometry.
+      #ifdef USE_NORMAL
+        vec3 sphereNormal = normalize(sphereBase);
+        // Ground-level geometry follows the sphere, tall objects keep their own normals.
+        float normalBlend = clamp(1.0 - normalizedH * 2.0, 0.0, 1.0);
+        vNormal = normalize(mix(vNormal, mat3(viewMatrix) * sphereNormal, normalBlend));
+      #endif
 
-        mvPosition = viewMatrix * vec4(spherePos, 1.0);
-      } else {
-        // Cube-space fallback — plain model-view projection, no displacement.
-        mvPosition = modelViewMatrix * vec4(transformed, 1.0);
-      }
+      vec4 mvPosition = viewMatrix * vec4(spherePos, 1.0);
       gl_Position = projectionMatrix * mvPosition;
 
       #ifdef USE_FOG

--- a/src/diorama/TileGrid.tsx
+++ b/src/diorama/TileGrid.tsx
@@ -305,14 +305,27 @@ interface SphereUniforms {
   uFaceNormal: { value: THREE.Vector3 }
   uBezier: { value: THREE.Vector4 }  // (cx1, cy1, cx2, cy2)
   uMaxHeight: { value: number }
+  /** 1.0 = apply sphere projection, 0.0 = render in cube space (debug). */
+  uSphereProjectionEnabled: { value: number }
+}
+
+/**
+ * Module-level singleton — shared across every sphere-patched material.
+ * Exported so external controls (PostFx Leva) can toggle the projection
+ * at runtime for A/B debugging (e.g. to isolate N8AO's dependency on
+ * smooth-depth geometry vs our custom vertex displacement).
+ */
+export const sphereUniforms: SphereUniforms = {
+  uFaceNormal: { value: new THREE.Vector3(0, 1, 0) },
+  uBezier: { value: new THREE.Vector4(0.25, 0.1, 0.75, 0.9) },
+  uMaxHeight: { value: 1.0 },
+  uSphereProjectionEnabled: { value: 1.0 },
 }
 
 function createSphereUniforms(): SphereUniforms {
-  return {
-    uFaceNormal: { value: new THREE.Vector3(0, 1, 0) },
-    uBezier: { value: new THREE.Vector4(0.25, 0.1, 0.75, 0.9) },
-    uMaxHeight: { value: 1.0 },
-  }
+  // Per-mount: reuse the module-level singleton so Leva writes are seen
+  // by every patched material immediately.
+  return sphereUniforms
 }
 
 function patchMaterialForSphere(material: THREE.Material, uniforms: SphereUniforms) {
@@ -335,12 +348,15 @@ function patchMaterialForSphere(material: THREE.Material, uniforms: SphereUnifor
     shader.uniforms.uBezier = uniforms.uBezier
     shader.uniforms.uMaxHeight = uniforms.uMaxHeight
 
+    shader.uniforms.uSphereProjectionEnabled = uniforms.uSphereProjectionEnabled
+
     shader.vertexShader = shader.vertexShader.replace(
       '#include <common>',
       `#include <common>
       uniform vec3 uFaceNormal;
       uniform vec4 uBezier;    // (cx1, cy1, cx2, cy2)
       uniform float uMaxHeight;
+      uniform float uSphereProjectionEnabled;
 
       // Cubic bezier evaluation
       float cbez(float t, float p0, float p1, float p2, float p3) {
@@ -372,7 +388,9 @@ function patchMaterialForSphere(material: THREE.Material, uniforms: SphereUnifor
       }`,
     )
 
-    // Replace project_vertex with additive sphere projection
+    // Replace project_vertex with additive sphere projection.
+    // uSphereProjectionEnabled gates the curvature: 1.0 → sphere-project,
+    // 0.0 → cube-space fallback (standard MVP). Debug toggle from PostFx.
     shader.vertexShader = shader.vertexShader.replace(
       '#include <project_vertex>',
       `
@@ -381,33 +399,39 @@ function patchMaterialForSphere(material: THREE.Material, uniforms: SphereUnifor
         vClipPosition = -(modelViewMatrix * vec4(transformed, 1.0)).xyz;
       #endif
 
-      // Sphere projection with bezier height curve
-      vec4 worldPos = modelMatrix * vec4(transformed, 1.0);
-      vec3 wp = worldPos.xyz;
-      float faceDistance = dot(wp, uFaceNormal);
-      float rawHeight = faceDistance - 1.0;
+      vec4 mvPosition;
+      if (uSphereProjectionEnabled > 0.5) {
+        // Sphere projection with bezier height curve
+        vec4 worldPos = modelMatrix * vec4(transformed, 1.0);
+        vec3 wp = worldPos.xyz;
+        float faceDistance = dot(wp, uFaceNormal);
+        float rawHeight = faceDistance - 1.0;
 
-      // Apply bezier curve to normalized height
-      float normalizedH = clamp(rawHeight / uMaxHeight, 0.0, 1.0);
-      float curvedH = rawHeight <= 0.0 ? rawHeight : evalHeightCurve(normalizedH) * uMaxHeight;
+        // Apply bezier curve to normalized height
+        float normalizedH = clamp(rawHeight / uMaxHeight, 0.0, 1.0);
+        float curvedH = rawHeight <= 0.0 ? rawHeight : evalHeightCurve(normalizedH) * uMaxHeight;
 
-      vec3 basePoint = wp - rawHeight * uFaceNormal;
-      vec3 sphereBase = normalize(basePoint);
-      vec3 spherePos = sphereBase * (1.0 + curvedH);
+        vec3 basePoint = wp - rawHeight * uFaceNormal;
+        vec3 sphereBase = normalize(basePoint);
+        vec3 spherePos = sphereBase * (1.0 + curvedH);
 
-      // Correct normals for sphere curvature.
-      // sphereNormal is WORLD-space (radial from origin). To land in view
-      // space we apply mat3(viewMatrix), not normalMatrix — the latter
-      // expects object-space input and would yield a garbage direction,
-      // corrupting N·V and therefore Fresnel on ground geometry.
-      #ifdef USE_NORMAL
-        vec3 sphereNormal = normalize(sphereBase);
-        // Ground-level geometry follows the sphere, tall objects keep their own normals.
-        float normalBlend = clamp(1.0 - normalizedH * 2.0, 0.0, 1.0);
-        vNormal = normalize(mix(vNormal, mat3(viewMatrix) * sphereNormal, normalBlend));
-      #endif
+        // Correct normals for sphere curvature.
+        // sphereNormal is WORLD-space (radial from origin). To land in view
+        // space we apply mat3(viewMatrix), not normalMatrix — the latter
+        // expects object-space input and would yield a garbage direction,
+        // corrupting N·V and therefore Fresnel on ground geometry.
+        #ifdef USE_NORMAL
+          vec3 sphereNormal = normalize(sphereBase);
+          // Ground-level geometry follows the sphere, tall objects keep their own normals.
+          float normalBlend = clamp(1.0 - normalizedH * 2.0, 0.0, 1.0);
+          vNormal = normalize(mix(vNormal, mat3(viewMatrix) * sphereNormal, normalBlend));
+        #endif
 
-      vec4 mvPosition = viewMatrix * vec4(spherePos, 1.0);
+        mvPosition = viewMatrix * vec4(spherePos, 1.0);
+      } else {
+        // Cube-space fallback — plain model-view projection, no displacement.
+        mvPosition = modelViewMatrix * vec4(transformed, 1.0);
+      }
       gl_Position = projectionMatrix * mvPosition;
 
       #ifdef USE_FOG

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -154,7 +154,7 @@ export function PostFx() {
       motionBlurJitter: { value: 1, min: 0, max: 4, step: 0.05, label: 'jitter' },
       motionBlurSamples: { value: 16, min: 4, max: 64, step: 1, label: 'samples' },
     }, { collapsed: true }),
-  }, { collapsed: true })
+  })
 
   // Live-tune the renderer's tone-mapping exposure. ACES compresses highlights,
   // so this is the knob to keep bright zones from feeling dim.

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useRef, useState } from 'react'
-import { EffectComposer, Bloom, Vignette } from '@react-three/postprocessing'
+import {
+  EffectComposer,
+  Bloom,
+  DepthOfField,
+  N8AO,
+  Noise,
+  SMAA,
+  Vignette,
+} from '@react-three/postprocessing'
+import { BlendFunction } from 'postprocessing'
 import { usePlanet } from './store'
 
 function lerp(a: number, b: number, t: number) {
@@ -12,6 +21,27 @@ function smoothstep(t: number) {
 
 const WARM_DURATION_MS = 2000
 
+/**
+ * Path-1 effect stack (pmndrs ecosystem only, zero new deps):
+ *
+ *   render → SMAA → N8AO → DoF → Bloom → Noise → Vignette → screen
+ *
+ * Ordering rationale:
+ *   SMAA first so later passes operate on anti-aliased color
+ *   N8AO early — occlusion multiplies color, should land before bloom boost
+ *   DoF before bloom so bloom doesn't bleed through blurred regions
+ *   Bloom before noise/vignette so the grain + edge darkness read on top
+ *
+ * Architecture notes (required for Path-2 readiness — see
+ * project_postfx_strategy.md):
+ *   • multisampling={0} on EffectComposer — SSGI later needs full MSAA control
+ *   • ACES ToneMapping lives on the RENDERER (App.tsx Canvas gl prop), NOT
+ *     in the effect chain, so passes read linear color
+ *   • <Canvas antialias={false}> — SMAA in chain replaces MSAA edges
+ *   • usePlanet.sceneGrade flag is plumbed but unused at Path 1. Path 2
+ *     will gate realism-effects (SSGI / TRAA / motion blur) behind
+ *     sceneGrade === 'photoreal'
+ */
 export function PostFx() {
   const solved = usePlanet(s => s.solved)
   const [warmth, setWarmth] = useState(solved ? 1 : 0)
@@ -37,13 +67,25 @@ export function PostFx() {
   const vignetteDarkness = lerp(0.45, 0.62, warmth)
 
   return (
-    <EffectComposer>
+    <EffectComposer multisampling={0}>
+      <SMAA />
+      {/* N8AO — grounds diorama props (huts, trees, well, bridge) to terrain.
+          Tuned subtle for the stylized scale (unit sphere, tiny props): too
+          strong and the triplanar grass gets crushed. */}
+      <N8AO aoRadius={0.15} intensity={1.4} distanceFalloff={0.5} quality="medium" />
+      {/* DoF — subtle focus on the planet centre. focusDistance is in
+          normalised camera space (0=near, 1=far). Planet sits at roughly
+          0.015 with our near=0.01 far=default. Keep focalLength generous
+          and bokehScale small so the diorama stays readable — strong DoF
+          smears the low-poly silhouettes. */}
+      <DepthOfField focusDistance={0.018} focalLength={0.12} bokehScale={1.4} />
       <Bloom
         intensity={bloomIntensity}
         luminanceThreshold={0.55}
         luminanceSmoothing={0.4}
         mipmapBlur
       />
+      <Noise premultiply blendFunction={BlendFunction.SOFT_LIGHT} opacity={0.08} />
       <Vignette darkness={vignetteDarkness} offset={0.3} eskil={false} />
     </EffectComposer>
   )

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -12,6 +12,7 @@ import {
 import { BlendFunction } from 'postprocessing'
 import { folder, useControls } from 'leva'
 import { usePlanet } from './store'
+import { RealismFX } from './RealismFX'
 
 function lerp(a: number, b: number, t: number) {
   return a + (b - a) * t
@@ -58,6 +59,9 @@ export function PostFx() {
     bloomEnabled, bloomScrambled, bloomSolved, bloomThreshold, bloomSmoothing,
     noiseEnabled, noiseOpacity,
     vignetteEnabled, vignetteScrambled, vignetteSolved, vignetteOffset,
+    ssgiEnabled, ssgiDistance, ssgiThickness, ssgiBlend, ssgiDenoiseIterations,
+    ssrEnabled,
+    motionBlurEnabled, motionBlurIntensity, motionBlurJitter, motionBlurSamples,
   } = useControls('PostFx', {
     exposure: { value: 1.35, min: 0.3, max: 3, step: 0.05, label: 'Exposure (ACES)' },
     SMAA: folder({
@@ -97,6 +101,26 @@ export function PostFx() {
       vignetteSolved: { value: 0.62, min: 0, max: 1.5, step: 0.01, label: 'darkness (solved)' },
       vignetteOffset: { value: 0.3, min: 0, max: 1, step: 0.01, label: 'offset' },
     }, { collapsed: true }),
+    // Path 2 — realism-effects (SSGI / SSR / motion blur). Default OFF
+    // because the current stylized diorama has near-zero PBR surfaces; SSGI
+    // on low-poly vertex-coloured meshes reads as noise. Flip to 'on' when
+    // the photoreal Blender diorama is loaded.
+    'SSGI (experimental, broken on three 0.183)': folder({
+      ssgiEnabled: { value: false, label: 'on — GLSL shader incompat, see RealismFX.tsx' },
+      ssgiDistance: { value: 10, min: 0.1, max: 50, step: 0.5, label: 'ray distance' },
+      ssgiThickness: { value: 10, min: 0.1, max: 50, step: 0.5, label: 'thickness' },
+      ssgiBlend: { value: 0.9, min: 0, max: 1, step: 0.01, label: 'temporal blend' },
+      ssgiDenoiseIterations: { value: 1, min: 0, max: 4, step: 1, label: 'denoise iter' },
+    }, { collapsed: true }),
+    'SSR (experimental, broken on three 0.183)': folder({
+      ssrEnabled: { value: false, label: 'on — GLSL shader incompat, see RealismFX.tsx' },
+    }, { collapsed: true }),
+    'Motion Blur (experimental)': folder({
+      motionBlurEnabled: { value: false, label: 'on — works on three 0.183 ✓' },
+      motionBlurIntensity: { value: 1, min: 0, max: 4, step: 0.05, label: 'intensity' },
+      motionBlurJitter: { value: 1, min: 0, max: 4, step: 0.05, label: 'jitter' },
+      motionBlurSamples: { value: 16, min: 4, max: 64, step: 1, label: 'samples' },
+    }, { collapsed: true }),
   }, { collapsed: true })
 
   // Live-tune the renderer's tone-mapping exposure. ACES compresses highlights,
@@ -124,8 +148,13 @@ export function PostFx() {
   const bloomIntensity = lerp(bloomScrambled, bloomSolved, warmth)
   const vignetteDarkness = lerp(vignetteScrambled, vignetteSolved, warmth)
 
+  // enableNormalPass is needed by SSGI's G-buffer reads. Turning it on when
+  // SSGI is off is a minor waste (~one extra render pass) — leave it gated
+  // so the common Path-1 case stays cheap.
+  const needNormalPass = ssgiEnabled || ssrEnabled
+
   return (
-    <EffectComposer multisampling={0}>
+    <EffectComposer multisampling={0} enableNormalPass={needNormalPass}>
       {smaaEnabled ? <SMAA /> : <></>}
       {n8aoEnabled ? (
         <N8AO
@@ -156,6 +185,18 @@ export function PostFx() {
       {vignetteEnabled ? (
         <Vignette darkness={vignetteDarkness} offset={vignetteOffset} eskil={false} />
       ) : <></>}
+      <RealismFX
+        ssgi={ssgiEnabled}
+        ssr={ssrEnabled}
+        motionBlur={motionBlurEnabled}
+        ssgiDistance={ssgiDistance}
+        ssgiThickness={ssgiThickness}
+        ssgiBlend={ssgiBlend}
+        ssgiDenoiseIterations={ssgiDenoiseIterations}
+        motionBlurIntensity={motionBlurIntensity}
+        motionBlurJitter={motionBlurJitter}
+        motionBlurSamples={motionBlurSamples}
+      />
     </EffectComposer>
   )
 }

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -59,7 +59,11 @@ export function PostFx() {
     bloomEnabled, bloomScrambled, bloomSolved, bloomThreshold, bloomSmoothing,
     noiseEnabled, noiseOpacity,
     vignetteEnabled, vignetteScrambled, vignetteSolved, vignetteOffset,
-    ssgiEnabled, ssgiDistance, ssgiThickness, ssgiBlend, ssgiDenoiseIterations,
+    ssgiEnabled, ssgiDistance, ssgiThickness, ssgiAutoThickness, ssgiMaxRoughness,
+    ssgiBlend, ssgiImportanceSampling, ssgiDirectLightMultiplier, ssgiEnvBlur,
+    ssgiSteps, ssgiRefineSteps, ssgiSpp, ssgiResolutionScale, ssgiMissedRays,
+    ssgiDenoiseIterations, ssgiDenoiseKernel, ssgiDenoiseDiffuse, ssgiDenoiseSpecular,
+    ssgiDepthPhi, ssgiNormalPhi, ssgiRoughnessPhi,
     ssrEnabled,
     motionBlurEnabled, motionBlurIntensity, motionBlurJitter, motionBlurSamples,
   } = useControls('PostFx', {
@@ -105,18 +109,47 @@ export function PostFx() {
     // because the current stylized diorama has near-zero PBR surfaces; SSGI
     // on low-poly vertex-coloured meshes reads as noise. Flip to 'on' when
     // the photoreal Blender diorama is loaded.
-    'SSGI (experimental)': folder({
-      ssgiEnabled: { value: false, label: 'on — works on three 0.183 ✓' },
-      ssgiDistance: { value: 10, min: 0.1, max: 50, step: 0.5, label: 'ray distance' },
-      ssgiThickness: { value: 10, min: 0.1, max: 50, step: 0.5, label: 'thickness' },
-      ssgiBlend: { value: 0.9, min: 0, max: 1, step: 0.01, label: 'temporal blend' },
-      ssgiDenoiseIterations: { value: 1, min: 0, max: 4, step: 1, label: 'denoise iter' },
+    // Realism-effects (SSGI + SSR + motion blur). Defaults OFF — visual
+    // impact is subtle on the stylized test diorama; SSR needs reflective
+    // PBR materials to shine. Will earn its keep on the photoreal Blender
+    // diorama. Param groupings mirror realism-effects' SSGIEffect constructor.
+    SSGI: folder({
+      ssgiEnabled: { value: false, label: 'on' },
+      'SSGI — rays': folder({
+        ssgiDistance: { value: 10, min: 0.1, max: 100, step: 0.5, label: 'ray distance' },
+        ssgiThickness: { value: 10, min: 0.1, max: 100, step: 0.5, label: 'thickness' },
+        ssgiAutoThickness: { value: false, label: 'auto thickness' },
+        ssgiMaxRoughness: { value: 1, min: 0, max: 1, step: 0.01, label: 'max roughness' },
+        ssgiSteps: { value: 20, min: 1, max: 128, step: 1, label: 'march steps' },
+        ssgiRefineSteps: { value: 5, min: 0, max: 32, step: 1, label: 'refine steps' },
+        ssgiSpp: { value: 1, min: 1, max: 8, step: 1, label: 'samples/pixel' },
+        ssgiMissedRays: { value: false, label: 'sample missed (env)' },
+      }, { collapsed: true }),
+      'SSGI — temporal': folder({
+        ssgiBlend: { value: 0.9, min: 0, max: 1, step: 0.01, label: 'temporal blend' },
+        ssgiImportanceSampling: { value: true, label: 'importance sampling' },
+        ssgiDirectLightMultiplier: { value: 1, min: 0, max: 8, step: 0.05, label: 'direct light ×' },
+        ssgiEnvBlur: { value: 0.5, min: 0, max: 1, step: 0.01, label: 'env blur' },
+      }, { collapsed: true }),
+      'SSGI — denoise': folder({
+        ssgiDenoiseIterations: { value: 1, min: 0, max: 8, step: 1, label: 'iterations' },
+        ssgiDenoiseKernel: { value: 2, min: 1, max: 6, step: 1, label: 'kernel' },
+        ssgiDenoiseDiffuse: { value: 10, min: 0, max: 50, step: 0.5, label: 'diffuse weight' },
+        ssgiDenoiseSpecular: { value: 10, min: 0, max: 50, step: 0.5, label: 'specular weight' },
+        ssgiDepthPhi: { value: 2, min: 0, max: 50, step: 0.1, label: 'depth φ' },
+        ssgiNormalPhi: { value: 50, min: 0, max: 100, step: 1, label: 'normal φ' },
+        ssgiRoughnessPhi: { value: 1, min: 0, max: 10, step: 0.05, label: 'roughness φ' },
+      }, { collapsed: true }),
+      'SSGI — perf': folder({
+        ssgiResolutionScale: { value: 1, min: 0.25, max: 1, step: 0.05, label: 'res scale' },
+      }, { collapsed: true }),
     }, { collapsed: true }),
-    'SSR (experimental)': folder({
-      ssrEnabled: { value: false, label: 'on — works on three 0.183 ✓ (shares SSGI opts)' },
+    SSR: folder({
+      // SSREffect extends SSGIEffect — all SSGI options apply.
+      ssrEnabled: { value: false, label: 'on (inherits all SSGI params above)' },
     }, { collapsed: true }),
-    'Motion Blur (experimental)': folder({
-      motionBlurEnabled: { value: false, label: 'on — works on three 0.183 ✓' },
+    'Motion Blur': folder({
+      motionBlurEnabled: { value: false, label: 'on' },
       motionBlurIntensity: { value: 1, min: 0, max: 4, step: 0.05, label: 'intensity' },
       motionBlurJitter: { value: 1, min: 0, max: 4, step: 0.05, label: 'jitter' },
       motionBlurSamples: { value: 16, min: 4, max: 64, step: 1, label: 'samples' },
@@ -191,8 +224,24 @@ export function PostFx() {
         motionBlur={motionBlurEnabled}
         ssgiDistance={ssgiDistance}
         ssgiThickness={ssgiThickness}
+        ssgiAutoThickness={ssgiAutoThickness}
+        ssgiMaxRoughness={ssgiMaxRoughness}
         ssgiBlend={ssgiBlend}
         ssgiDenoiseIterations={ssgiDenoiseIterations}
+        ssgiDenoiseKernel={ssgiDenoiseKernel}
+        ssgiDenoiseDiffuse={ssgiDenoiseDiffuse}
+        ssgiDenoiseSpecular={ssgiDenoiseSpecular}
+        ssgiDepthPhi={ssgiDepthPhi}
+        ssgiNormalPhi={ssgiNormalPhi}
+        ssgiRoughnessPhi={ssgiRoughnessPhi}
+        ssgiEnvBlur={ssgiEnvBlur}
+        ssgiImportanceSampling={ssgiImportanceSampling}
+        ssgiDirectLightMultiplier={ssgiDirectLightMultiplier}
+        ssgiSteps={ssgiSteps}
+        ssgiRefineSteps={ssgiRefineSteps}
+        ssgiSpp={ssgiSpp}
+        ssgiResolutionScale={ssgiResolutionScale}
+        ssgiMissedRays={ssgiMissedRays}
         motionBlurIntensity={motionBlurIntensity}
         motionBlurJitter={motionBlurJitter}
         motionBlurSamples={motionBlurSamples}

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -58,7 +58,7 @@ export function PostFx() {
     exposure,
     smaaEnabled,
     n8aoEnabled, n8aoRadius, n8aoIntensity, n8aoFalloff, n8aoQuality,
-    dofEnabled, dofFollowCursor, dofFocalLength, dofBokehScale, dofSmoothing,
+    dofEnabled, dofFollowCursor, dofFocusRange, dofBokehScale, dofSmoothing,
     bloomEnabled, bloomScrambled, bloomSolved, bloomThreshold, bloomSmoothing,
     noiseEnabled, noiseOpacity,
     vignetteEnabled, vignetteScrambled, vignetteSolved, vignetteOffset,
@@ -88,8 +88,14 @@ export function PostFx() {
     'Depth of Field': folder({
       dofEnabled: { value: true, label: 'on' },
       dofFollowCursor: { value: true, label: 'follow cursor (else planet)' },
-      dofFocalLength: { value: 0.12, min: 0.01, max: 0.5, step: 0.01, label: 'focal len' },
-      dofBokehScale: { value: 1.4, min: 0, max: 8, step: 0.1, label: 'bokeh' },
+      // In postprocessing 6.x, `focalLength` is deprecated and aliases
+      // `focusRange` — the WIDTH of the sharp slab in world units. Our
+      // planet has radius 1, so 2.5 comfortably covers it at any orbit
+      // distance. Small values (<0.5) produce a thin slice where only
+      // the target point is sharp — useful for tight focal effects, but
+      // makes the whole-planet-sharp case impossible.
+      dofFocusRange: { value: 2.5, min: 0.1, max: 10, step: 0.1, label: 'focus range (world)' },
+      dofBokehScale: { value: 1.0, min: 0, max: 8, step: 0.1, label: 'bokeh' },
       dofSmoothing: { value: 0.18, min: 0.01, max: 1, step: 0.01, label: 'follow speed' },
     }, { collapsed: true }),
     Bloom: folder({
@@ -242,7 +248,7 @@ export function PostFx() {
       {dofEnabled ? (
         <DepthOfField
           ref={dofRef}
-          focalLength={dofFocalLength}
+          worldFocusRange={dofFocusRange}
           bokehScale={dofBokehScale}
         />
       ) : <></>}

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -105,15 +105,15 @@ export function PostFx() {
     // because the current stylized diorama has near-zero PBR surfaces; SSGI
     // on low-poly vertex-coloured meshes reads as noise. Flip to 'on' when
     // the photoreal Blender diorama is loaded.
-    'SSGI (experimental, broken on three 0.183)': folder({
-      ssgiEnabled: { value: false, label: 'on — GLSL shader incompat, see RealismFX.tsx' },
+    'SSGI (experimental)': folder({
+      ssgiEnabled: { value: false, label: 'on — works on three 0.183 ✓' },
       ssgiDistance: { value: 10, min: 0.1, max: 50, step: 0.5, label: 'ray distance' },
       ssgiThickness: { value: 10, min: 0.1, max: 50, step: 0.5, label: 'thickness' },
       ssgiBlend: { value: 0.9, min: 0, max: 1, step: 0.01, label: 'temporal blend' },
       ssgiDenoiseIterations: { value: 1, min: 0, max: 4, step: 1, label: 'denoise iter' },
     }, { collapsed: true }),
-    'SSR (experimental, broken on three 0.183)': folder({
-      ssrEnabled: { value: false, label: 'on — GLSL shader incompat, see RealismFX.tsx' },
+    'SSR (experimental)': folder({
+      ssrEnabled: { value: false, label: 'on — works on three 0.183 ✓ (shares SSGI opts)' },
     }, { collapsed: true }),
     'Motion Blur (experimental)': folder({
       motionBlurEnabled: { value: false, label: 'on — works on three 0.183 ✓' },

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -58,7 +58,7 @@ export function PostFx() {
     exposure,
     smaaEnabled,
     n8aoEnabled, n8aoRadius, n8aoIntensity, n8aoFalloff, n8aoQuality,
-    dofEnabled, dofFollowCursor, dofFocusRange, dofBokehScale, dofSmoothing,
+    dofEnabled, dofFollowCursor, dofFocusRange, dofBokehScale, dofSmoothing, dofDebugTarget,
     bloomEnabled, bloomScrambled, bloomSolved, bloomThreshold, bloomSmoothing,
     noiseEnabled, noiseOpacity,
     vignetteEnabled, vignetteScrambled, vignetteSolved, vignetteOffset,
@@ -89,14 +89,11 @@ export function PostFx() {
       dofEnabled: { value: true, label: 'on' },
       dofFollowCursor: { value: true, label: 'follow cursor (else planet)' },
       // In postprocessing 6.x, `focalLength` is deprecated and aliases
-      // `focusRange` — the WIDTH of the sharp slab in world units. Our
-      // planet has radius 1, so 2.5 comfortably covers it at any orbit
-      // distance. Small values (<0.5) produce a thin slice where only
-      // the target point is sharp — useful for tight focal effects, but
-      // makes the whole-planet-sharp case impossible.
-      dofFocusRange: { value: 2.5, min: 0.1, max: 10, step: 0.1, label: 'focus range (world)' },
+      // `focusRange` — the WIDTH of the sharp slab in world units.
+      dofFocusRange: { value: 2.5, min: 0.05, max: 10, step: 0.05, label: 'focus range (world)' },
       dofBokehScale: { value: 1.0, min: 0, max: 8, step: 0.1, label: 'bokeh' },
       dofSmoothing: { value: 0.18, min: 0.01, max: 1, step: 0.01, label: 'follow speed' },
+      dofDebugTarget: { value: false, label: 'debug: show target' },
     }, { collapsed: true }),
     Bloom: folder({
       bloomEnabled: { value: true, label: 'on' },
@@ -188,26 +185,38 @@ export function PostFx() {
   const dofTarget = useMemo(() => new THREE.Vector3(), [])
   const dofDesired = useMemo(() => new THREE.Vector3(), [])
 
+  // Dev hooks — attached once.
   useLayoutEffect(() => {
-    if (!dofEnabled || !dofRef.current) return
-    dofRef.current.target = dofTarget
     if (import.meta.env.DEV) {
-      ;(window as unknown as Record<string, unknown>).__dofEffect = dofRef.current
       ;(window as unknown as Record<string, unknown>).__dofTarget = dofTarget
     }
-    return () => {
-      if (dofRef.current) dofRef.current.target = null
-    }
-  }, [dofEnabled, dofTarget])
+  }, [dofTarget])
+
+  // Debug sphere position ref — drives a <mesh> whose position tracks dofTarget.
+  const debugMeshRef = useRef<THREE.Mesh | null>(null)
 
   useFrame(() => {
     if (!dofEnabled || !dofRef.current) return
+
+    // @react-three/postprocessing's DoF wrapper re-instantiates its internal
+    // effect whenever any config prop changes (worldFocusRange slider,
+    // bokehScale, ...). The new instance's .target is reset to a placeholder
+    // Vector3. Re-attach every frame if the ref has swapped out — cheap
+    // identity check, keeps our lerp target wired to the live effect.
+    if (dofRef.current.target !== dofTarget) {
+      dofRef.current.target = dofTarget
+      if (import.meta.env.DEV) {
+        ;(window as unknown as Record<string, unknown>).__dofEffect = dofRef.current
+      }
+    }
+
     const active = hudUniforms.uHudCursorActive.value > 0 && dofFollowCursor
     if (active) dofDesired.copy(hudUniforms.uHudCursor.value)
     else dofDesired.set(0, 0, 0)
     // Frame-rate-independent ease: the same `dofSmoothing` feels the same
     // at 30 or 120 fps. Clamp to 1 so the max smoothing snaps instantly.
     dofTarget.lerp(dofDesired, Math.min(1, dofSmoothing))
+    if (debugMeshRef.current) debugMeshRef.current.position.copy(dofTarget)
   })
 
   useEffect(() => {
@@ -235,6 +244,13 @@ export function PostFx() {
   const needNormalPass = ssgiEnabled || ssrEnabled
 
   return (
+    <>
+      {dofEnabled && dofDebugTarget ? (
+        <mesh ref={debugMeshRef} renderOrder={9999}>
+          <sphereGeometry args={[0.05, 16, 16]} />
+          <meshBasicMaterial color="#ff00ff" depthTest={false} depthWrite={false} />
+        </mesh>
+      ) : null}
     <EffectComposer multisampling={0} enableNormalPass={needNormalPass}>
       {smaaEnabled ? <SMAA /> : <></>}
       {n8aoEnabled ? (
@@ -295,5 +311,6 @@ export function PostFx() {
         motionBlurSamples={motionBlurSamples}
       />
     </EffectComposer>
+    </>
   )
 }

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -57,7 +57,9 @@ export function PostFx() {
   const {
     exposure,
     smaaEnabled,
-    n8aoEnabled, n8aoRadius, n8aoIntensity, n8aoFalloff, n8aoQuality,
+    n8aoEnabled, n8aoRadius, n8aoScreenSpaceRadius, n8aoIntensity, n8aoFalloff,
+    n8aoSamples, n8aoDenoiseSamples, n8aoDenoiseRadius, n8aoHalfRes,
+    n8aoColor, n8aoRenderMode, n8aoQuality,
     dofEnabled, dofFollowCursor, dofFocusRange, dofBokehScale, dofSmoothing, dofDebugTarget,
     bloomEnabled, bloomScrambled, bloomSolved, bloomThreshold, bloomSmoothing,
     noiseEnabled, noiseOpacity,
@@ -76,13 +78,27 @@ export function PostFx() {
     }, { collapsed: true }),
     N8AO: folder({
       n8aoEnabled: { value: true, label: 'on' },
-      n8aoRadius: { value: 0.15, min: 0.01, max: 2, step: 0.01, label: 'radius' },
-      n8aoIntensity: { value: 1.4, min: 0, max: 8, step: 0.1, label: 'intensity' },
-      n8aoFalloff: { value: 0.5, min: 0, max: 3, step: 0.05, label: 'falloff' },
+      // aoRadius is in WORLD units (unless screenSpaceRadius is on). Our
+      // planet is 2m diameter with props sticking out up to ~0.3m — a 0.5m
+      // occlusion kernel gives visible grounding around their bases.
+      n8aoRadius: { value: 0.5, min: 0.01, max: 5, step: 0.01, label: 'radius (world)' },
+      n8aoScreenSpaceRadius: { value: false, label: 'radius in screen px' },
+      n8aoIntensity: { value: 3, min: 0, max: 16, step: 0.1, label: 'intensity' },
+      n8aoFalloff: { value: 1, min: 0, max: 3, step: 0.05, label: 'distance falloff' },
+      n8aoSamples: { value: 16, min: 4, max: 64, step: 1, label: 'ao samples' },
+      n8aoDenoiseSamples: { value: 4, min: 1, max: 16, step: 1, label: 'denoise samples' },
+      n8aoDenoiseRadius: { value: 12, min: 1, max: 32, step: 1, label: 'denoise radius' },
+      n8aoHalfRes: { value: false, label: 'half-res (faster, softer)' },
+      n8aoColor: { value: '#000000', label: 'AO colour' },
+      n8aoRenderMode: {
+        value: 'Combined',
+        options: ['Combined', 'AO', 'No AO', 'Split', 'Split AO'],
+        label: 'render mode',
+      },
       n8aoQuality: {
         value: 'medium',
         options: ['performance', 'low', 'medium', 'high', 'ultra'],
-        label: 'quality',
+        label: 'quality preset',
       },
     }, { collapsed: true }),
     'Depth of Field': folder({
@@ -256,8 +272,21 @@ export function PostFx() {
       {n8aoEnabled ? (
         <N8AO
           aoRadius={n8aoRadius}
+          screenSpaceRadius={n8aoScreenSpaceRadius}
           intensity={n8aoIntensity}
           distanceFalloff={n8aoFalloff}
+          aoSamples={n8aoSamples}
+          denoiseSamples={n8aoDenoiseSamples}
+          denoiseRadius={n8aoDenoiseRadius}
+          halfRes={n8aoHalfRes}
+          color={n8aoColor}
+          renderMode={
+            n8aoRenderMode === 'AO' ? 1
+              : n8aoRenderMode === 'No AO' ? 2
+              : n8aoRenderMode === 'Split' ? 3
+              : n8aoRenderMode === 'Split AO' ? 4
+              : 0 /* Combined */
+          }
           quality={n8aoQuality as 'performance' | 'low' | 'medium' | 'high' | 'ultra'}
         />
       ) : <></>}

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -17,7 +17,6 @@ import { folder, useControls } from 'leva'
 import { usePlanet } from './store'
 import { RealismFX } from './RealismFX'
 import { hudUniforms } from '../diorama/buildDiorama'
-import { sphereUniforms } from '../diorama/TileGrid'
 
 function lerp(a: number, b: number, t: number) {
   return a + (b - a) * t
@@ -73,10 +72,8 @@ export function PostFx() {
     ssgiDepthPhi, ssgiNormalPhi, ssgiRoughnessPhi,
     ssrEnabled,
     motionBlurEnabled, motionBlurIntensity, motionBlurJitter, motionBlurSamples,
-    sphereProjection,
   } = useControls('PostFx', {
     exposure: { value: 1.35, min: 0.3, max: 3, step: 0.05, label: 'Exposure (ACES)' },
-    sphereProjection: { value: true, label: 'Sphere projection (debug off = cube)' },
     SMAA: folder({
       smaaEnabled: { value: true, label: 'on' },
     }, { collapsed: true }),
@@ -188,14 +185,6 @@ export function PostFx() {
   useEffect(() => {
     gl.toneMappingExposure = exposure
   }, [gl, exposure])
-
-  // Debug toggle: disable sphere projection to render the diorama in cube
-  // space. Useful for isolating whether downstream effects (N8AO depth
-  // reconstruction, SSAO, etc.) are incompatible with the displacement
-  // vertex shader vs standard MVP geometry.
-  useEffect(() => {
-    sphereUniforms.uSphereProjectionEnabled.value = sphereProjection ? 1 : 0
-  }, [sphereProjection])
 
   // DoF target — world-space point the effect focuses on.
   //   • cursor off planet → ease toward planet origin (whole planet sharp)

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -17,6 +17,7 @@ import { folder, useControls } from 'leva'
 import { usePlanet } from './store'
 import { RealismFX } from './RealismFX'
 import { hudUniforms } from '../diorama/buildDiorama'
+import { sphereUniforms } from '../diorama/TileGrid'
 
 function lerp(a: number, b: number, t: number) {
   return a + (b - a) * t
@@ -72,8 +73,10 @@ export function PostFx() {
     ssgiDepthPhi, ssgiNormalPhi, ssgiRoughnessPhi,
     ssrEnabled,
     motionBlurEnabled, motionBlurIntensity, motionBlurJitter, motionBlurSamples,
+    sphereProjection,
   } = useControls('PostFx', {
     exposure: { value: 1.35, min: 0.3, max: 3, step: 0.05, label: 'Exposure (ACES)' },
+    sphereProjection: { value: true, label: 'Sphere projection (debug off = cube)' },
     SMAA: folder({
       smaaEnabled: { value: true, label: 'on' },
     }, { collapsed: true }),
@@ -185,6 +188,14 @@ export function PostFx() {
   useEffect(() => {
     gl.toneMappingExposure = exposure
   }, [gl, exposure])
+
+  // Debug toggle: disable sphere projection to render the diorama in cube
+  // space. Useful for isolating whether downstream effects (N8AO depth
+  // reconstruction, SSAO, etc.) are incompatible with the displacement
+  // vertex shader vs standard MVP geometry.
+  useEffect(() => {
+    sphereUniforms.uSphereProjectionEnabled.value = sphereProjection ? 1 : 0
+  }, [sphereProjection])
 
   // DoF target — world-space point the effect focuses on.
   //   • cursor off planet → ease toward planet origin (whole planet sharp)

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { useThree } from '@react-three/fiber'
 import {
   EffectComposer,
   Bloom,
@@ -9,6 +10,7 @@ import {
   Vignette,
 } from '@react-three/postprocessing'
 import { BlendFunction } from 'postprocessing'
+import { folder, useControls } from 'leva'
 import { usePlanet } from './store'
 
 function lerp(a: number, b: number, t: number) {
@@ -26,11 +28,11 @@ const WARM_DURATION_MS = 2000
  *
  *   render → SMAA → N8AO → DoF → Bloom → Noise → Vignette → screen
  *
- * Ordering rationale:
- *   SMAA first so later passes operate on anti-aliased color
- *   N8AO early — occlusion multiplies color, should land before bloom boost
- *   DoF before bloom so bloom doesn't bleed through blurred regions
- *   Bloom before noise/vignette so the grain + edge darkness read on top
+ * Every param is exposed via Leva under the 'PostFx' folder — individual
+ * per-effect enable toggles (for A/B), live tuning on sliders. Bloom and
+ * vignette expose both endpoints of their warmth ramp (scrambled → solved).
+ * The renderer's toneMappingExposure is also controlled from here so the
+ * ACES compression can be dialled against the HDRI in real time.
  *
  * Architecture notes (required for Path-2 readiness — see
  * project_postfx_strategy.md):
@@ -46,6 +48,62 @@ export function PostFx() {
   const solved = usePlanet(s => s.solved)
   const [warmth, setWarmth] = useState(solved ? 1 : 0)
   const fromRef = useRef(warmth)
+  const { gl } = useThree()
+
+  const {
+    exposure,
+    smaaEnabled,
+    n8aoEnabled, n8aoRadius, n8aoIntensity, n8aoFalloff, n8aoQuality,
+    dofEnabled, dofFocusDistance, dofFocalLength, dofBokehScale,
+    bloomEnabled, bloomScrambled, bloomSolved, bloomThreshold, bloomSmoothing,
+    noiseEnabled, noiseOpacity,
+    vignetteEnabled, vignetteScrambled, vignetteSolved, vignetteOffset,
+  } = useControls('PostFx', {
+    exposure: { value: 1.35, min: 0.3, max: 3, step: 0.05, label: 'Exposure (ACES)' },
+    SMAA: folder({
+      smaaEnabled: { value: true, label: 'on' },
+    }, { collapsed: true }),
+    N8AO: folder({
+      n8aoEnabled: { value: true, label: 'on' },
+      n8aoRadius: { value: 0.15, min: 0.01, max: 2, step: 0.01, label: 'radius' },
+      n8aoIntensity: { value: 1.4, min: 0, max: 8, step: 0.1, label: 'intensity' },
+      n8aoFalloff: { value: 0.5, min: 0, max: 3, step: 0.05, label: 'falloff' },
+      n8aoQuality: {
+        value: 'medium',
+        options: ['performance', 'low', 'medium', 'high', 'ultra'],
+        label: 'quality',
+      },
+    }, { collapsed: true }),
+    'Depth of Field': folder({
+      dofEnabled: { value: true, label: 'on' },
+      dofFocusDistance: { value: 0.018, min: 0, max: 0.2, step: 0.001, label: 'focus dist' },
+      dofFocalLength: { value: 0.12, min: 0.01, max: 0.5, step: 0.01, label: 'focal len' },
+      dofBokehScale: { value: 1.4, min: 0, max: 8, step: 0.1, label: 'bokeh' },
+    }, { collapsed: true }),
+    Bloom: folder({
+      bloomEnabled: { value: true, label: 'on' },
+      bloomScrambled: { value: 0.35, min: 0, max: 3, step: 0.05, label: 'intensity (unsolved)' },
+      bloomSolved: { value: 0.95, min: 0, max: 3, step: 0.05, label: 'intensity (solved)' },
+      bloomThreshold: { value: 0.55, min: 0, max: 1, step: 0.01, label: 'lum threshold' },
+      bloomSmoothing: { value: 0.4, min: 0, max: 1, step: 0.01, label: 'lum smooth' },
+    }, { collapsed: true }),
+    Noise: folder({
+      noiseEnabled: { value: true, label: 'on' },
+      noiseOpacity: { value: 0.08, min: 0, max: 1, step: 0.01, label: 'opacity' },
+    }, { collapsed: true }),
+    Vignette: folder({
+      vignetteEnabled: { value: true, label: 'on' },
+      vignetteScrambled: { value: 0.45, min: 0, max: 1.5, step: 0.01, label: 'darkness (unsolved)' },
+      vignetteSolved: { value: 0.62, min: 0, max: 1.5, step: 0.01, label: 'darkness (solved)' },
+      vignetteOffset: { value: 0.3, min: 0, max: 1, step: 0.01, label: 'offset' },
+    }, { collapsed: true }),
+  }, { collapsed: true })
+
+  // Live-tune the renderer's tone-mapping exposure. ACES compresses highlights,
+  // so this is the knob to keep bright zones from feeling dim.
+  useEffect(() => {
+    gl.toneMappingExposure = exposure
+  }, [gl, exposure])
 
   useEffect(() => {
     const start = performance.now()
@@ -63,30 +121,41 @@ export function PostFx() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [solved])
 
-  const bloomIntensity = lerp(0.35, 0.95, warmth)
-  const vignetteDarkness = lerp(0.45, 0.62, warmth)
+  const bloomIntensity = lerp(bloomScrambled, bloomSolved, warmth)
+  const vignetteDarkness = lerp(vignetteScrambled, vignetteSolved, warmth)
 
   return (
     <EffectComposer multisampling={0}>
-      <SMAA />
-      {/* N8AO — grounds diorama props (huts, trees, well, bridge) to terrain.
-          Tuned subtle for the stylized scale (unit sphere, tiny props): too
-          strong and the triplanar grass gets crushed. */}
-      <N8AO aoRadius={0.15} intensity={1.4} distanceFalloff={0.5} quality="medium" />
-      {/* DoF — subtle focus on the planet centre. focusDistance is in
-          normalised camera space (0=near, 1=far). Planet sits at roughly
-          0.015 with our near=0.01 far=default. Keep focalLength generous
-          and bokehScale small so the diorama stays readable — strong DoF
-          smears the low-poly silhouettes. */}
-      <DepthOfField focusDistance={0.018} focalLength={0.12} bokehScale={1.4} />
-      <Bloom
-        intensity={bloomIntensity}
-        luminanceThreshold={0.55}
-        luminanceSmoothing={0.4}
-        mipmapBlur
-      />
-      <Noise premultiply blendFunction={BlendFunction.SOFT_LIGHT} opacity={0.08} />
-      <Vignette darkness={vignetteDarkness} offset={0.3} eskil={false} />
+      {smaaEnabled ? <SMAA /> : <></>}
+      {n8aoEnabled ? (
+        <N8AO
+          aoRadius={n8aoRadius}
+          intensity={n8aoIntensity}
+          distanceFalloff={n8aoFalloff}
+          quality={n8aoQuality as 'performance' | 'low' | 'medium' | 'high' | 'ultra'}
+        />
+      ) : <></>}
+      {dofEnabled ? (
+        <DepthOfField
+          focusDistance={dofFocusDistance}
+          focalLength={dofFocalLength}
+          bokehScale={dofBokehScale}
+        />
+      ) : <></>}
+      {bloomEnabled ? (
+        <Bloom
+          intensity={bloomIntensity}
+          luminanceThreshold={bloomThreshold}
+          luminanceSmoothing={bloomSmoothing}
+          mipmapBlur
+        />
+      ) : <></>}
+      {noiseEnabled ? (
+        <Noise premultiply blendFunction={BlendFunction.SOFT_LIGHT} opacity={noiseOpacity} />
+      ) : <></>}
+      {vignetteEnabled ? (
+        <Vignette darkness={vignetteDarkness} offset={vignetteOffset} eskil={false} />
+      ) : <></>}
     </EffectComposer>
   )
 }

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -72,6 +72,11 @@ export function PostFx() {
     ssgiDepthPhi, ssgiNormalPhi, ssgiRoughnessPhi,
     ssrEnabled,
     motionBlurEnabled, motionBlurIntensity, motionBlurJitter, motionBlurSamples,
+    ssaoEnabled, ssaoSamples, ssaoRings, ssaoRadius, ssaoIntensity,
+    ssaoLuminanceInfluence, ssaoBias, ssaoFade, ssaoColor,
+    ssaoWorldDistanceThreshold, ssaoWorldDistanceFalloff,
+    ssaoWorldProximityThreshold, ssaoWorldProximityFalloff,
+    ssaoResolutionScale,
   } = useControls('PostFx', {
     exposure: { value: 1.35, min: 0.3, max: 3, step: 0.05, label: 'Exposure (ACES)' },
     SMAA: folder({
@@ -93,7 +98,7 @@ export function PostFx() {
       n8aoColor: { value: '#000000', label: 'AO colour' },
       n8aoRenderMode: {
         value: 'Combined',
-        options: ['Combined', 'AO', 'No AO', 'Split', 'Split AO', 'SSAO fallback'],
+        options: ['Combined', 'AO', 'No AO', 'Split', 'Split AO'],
         label: 'render mode',
       },
       n8aoQuality: {
@@ -101,6 +106,28 @@ export function PostFx() {
         options: ['performance', 'low', 'medium', 'high', 'ultra'],
         label: 'quality preset',
       },
+    }, { collapsed: true }),
+    // SSAO — pmndrs' classic hemispherical-sample SSAO. Works on our scene
+    // where N8AO's depth-derived normal reconstruction doesn't (sphere
+    // projection vertex shader defeats the neighbour-delta trick). Toggle
+    // on alongside or instead of N8AO.
+    SSAO: folder({
+      ssaoEnabled: { value: false, label: 'on' },
+      ssaoSamples: { value: 30, min: 1, max: 64, step: 1, label: 'samples' },
+      ssaoRings: { value: 4, min: 1, max: 16, step: 1, label: 'rings' },
+      ssaoRadius: { value: 0.1, min: 0.001, max: 2, step: 0.001, label: 'radius' },
+      ssaoIntensity: { value: 30, min: 0, max: 100, step: 0.5, label: 'intensity' },
+      ssaoLuminanceInfluence: { value: 0.6, min: 0, max: 1, step: 0.01, label: 'lum influence' },
+      ssaoBias: { value: 0.025, min: 0, max: 0.5, step: 0.001, label: 'bias' },
+      ssaoFade: { value: 0.01, min: 0, max: 0.5, step: 0.001, label: 'fade' },
+      ssaoColor: { value: '#000000', label: 'AO colour' },
+      ssaoResolutionScale: { value: 1, min: 0.25, max: 1, step: 0.05, label: 'res scale' },
+      'SSAO — world distance': folder({
+        ssaoWorldDistanceThreshold: { value: 1, min: 0, max: 10, step: 0.05, label: 'dist threshold' },
+        ssaoWorldDistanceFalloff: { value: 0.1, min: 0, max: 5, step: 0.05, label: 'dist falloff' },
+        ssaoWorldProximityThreshold: { value: 0.4, min: 0, max: 5, step: 0.01, label: 'prox threshold' },
+        ssaoWorldProximityFalloff: { value: 0.1, min: 0, max: 5, step: 0.01, label: 'prox falloff' },
+      }, { collapsed: true }),
     }, { collapsed: true }),
     'Depth of Field': folder({
       dofEnabled: { value: true, label: 'on' },
@@ -265,8 +292,7 @@ export function PostFx() {
   // enableNormalPass is needed by SSGI's G-buffer reads and by SSAO for
   // proper hemispherical sampling. Turning it on when none of those are
   // active is a minor waste (~one extra render pass).
-  const needNormalPass = ssgiEnabled || ssrEnabled ||
-    (n8aoEnabled && n8aoRenderMode === 'SSAO fallback')
+  const needNormalPass = ssgiEnabled || ssrEnabled || ssaoEnabled
 
   return (
     <>
@@ -278,7 +304,7 @@ export function PostFx() {
       ) : null}
     <EffectComposer multisampling={0} enableNormalPass={needNormalPass} stencilBuffer depthBuffer>
       {smaaEnabled ? <SMAA /> : <></>}
-      {n8aoEnabled && n8aoRenderMode !== 'SSAO fallback' ? (
+      {n8aoEnabled ? (
         <N8AO
           ref={n8aoRef}
           aoRadius={n8aoRadius}
@@ -300,17 +326,21 @@ export function PostFx() {
           quality={n8aoQuality as 'performance' | 'low' | 'medium' | 'high' | 'ultra'}
         />
       ) : <></>}
-      {n8aoEnabled && n8aoRenderMode === 'SSAO fallback' ? (
+      {ssaoEnabled ? (
         <SSAO
-          samples={31}
-          radius={n8aoRadius}
-          intensity={n8aoIntensity * 5}
-          luminanceInfluence={0.7}
-          color={n8aoColor}
-          worldDistanceThreshold={1}
-          worldDistanceFalloff={0.1}
-          worldProximityThreshold={0.4}
-          worldProximityFalloff={0.1}
+          samples={ssaoSamples}
+          rings={ssaoRings}
+          radius={ssaoRadius}
+          intensity={ssaoIntensity}
+          luminanceInfluence={ssaoLuminanceInfluence}
+          bias={ssaoBias}
+          fade={ssaoFade}
+          color={ssaoColor}
+          resolutionScale={ssaoResolutionScale}
+          worldDistanceThreshold={ssaoWorldDistanceThreshold}
+          worldDistanceFalloff={ssaoWorldDistanceFalloff}
+          worldProximityThreshold={ssaoWorldProximityThreshold}
+          worldProximityFalloff={ssaoWorldProximityFalloff}
         />
       ) : <></>}
       {dofEnabled ? (

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from 'react'
-import { useThree } from '@react-three/fiber'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useFrame, useThree } from '@react-three/fiber'
+import * as THREE from 'three'
 import {
   EffectComposer,
   Bloom,
@@ -13,6 +14,7 @@ import { BlendFunction } from 'postprocessing'
 import { folder, useControls } from 'leva'
 import { usePlanet } from './store'
 import { RealismFX } from './RealismFX'
+import { hudUniforms } from '../diorama/buildDiorama'
 
 function lerp(a: number, b: number, t: number) {
   return a + (b - a) * t
@@ -55,7 +57,7 @@ export function PostFx() {
     exposure,
     smaaEnabled,
     n8aoEnabled, n8aoRadius, n8aoIntensity, n8aoFalloff, n8aoQuality,
-    dofEnabled, dofFocusDistance, dofFocalLength, dofBokehScale,
+    dofEnabled, dofFollowCursor, dofFocalLength, dofBokehScale, dofSmoothing,
     bloomEnabled, bloomScrambled, bloomSolved, bloomThreshold, bloomSmoothing,
     noiseEnabled, noiseOpacity,
     vignetteEnabled, vignetteScrambled, vignetteSolved, vignetteOffset,
@@ -84,9 +86,10 @@ export function PostFx() {
     }, { collapsed: true }),
     'Depth of Field': folder({
       dofEnabled: { value: true, label: 'on' },
-      dofFocusDistance: { value: 0.018, min: 0, max: 0.2, step: 0.001, label: 'focus dist' },
+      dofFollowCursor: { value: true, label: 'follow cursor (else planet)' },
       dofFocalLength: { value: 0.12, min: 0.01, max: 0.5, step: 0.01, label: 'focal len' },
       dofBokehScale: { value: 1.4, min: 0, max: 8, step: 0.1, label: 'bokeh' },
+      dofSmoothing: { value: 0.18, min: 0.01, max: 1, step: 0.01, label: 'follow speed' },
     }, { collapsed: true }),
     Bloom: folder({
       bloomEnabled: { value: true, label: 'on' },
@@ -162,6 +165,24 @@ export function PostFx() {
     gl.toneMappingExposure = exposure
   }, [gl, exposure])
 
+  // DoF target — world-space point the effect focuses on.
+  //   • cursor off planet → ease toward planet origin (whole planet sharp)
+  //   • cursor on planet  → ease toward the raycast hit (uHudCursor)
+  // Interaction.tsx publishes hudUniforms.uHudCursor + uHudCursorActive on
+  // every pointermove raycast; TutorialHint publishes them when the tutorial
+  // is up. Either signal drives the focus naturally.
+  const dofTarget = useMemo(() => new THREE.Vector3(), [])
+  const dofDesired = useMemo(() => new THREE.Vector3(), [])
+  useFrame(() => {
+    if (!dofEnabled) return
+    const active = hudUniforms.uHudCursorActive.value > 0 && dofFollowCursor
+    if (active) dofDesired.copy(hudUniforms.uHudCursor.value)
+    else dofDesired.set(0, 0, 0)
+    // Frame-rate-independent ease: the same `dofSmoothing` feels the same
+    // at 30 or 120 fps. Clamp to 1 so the max smoothing snaps instantly.
+    dofTarget.lerp(dofDesired, Math.min(1, dofSmoothing))
+  })
+
   useEffect(() => {
     const start = performance.now()
     fromRef.current = warmth
@@ -199,7 +220,7 @@ export function PostFx() {
       ) : <></>}
       {dofEnabled ? (
         <DepthOfField
-          focusDistance={dofFocusDistance}
+          target={dofTarget}
           focalLength={dofFocalLength}
           bokehScale={dofBokehScale}
         />

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 import * as THREE from 'three'
+import type { DepthOfFieldEffect } from 'postprocessing'
 import {
   EffectComposer,
   Bloom,
@@ -171,10 +172,30 @@ export function PostFx() {
   // Interaction.tsx publishes hudUniforms.uHudCursor + uHudCursorActive on
   // every pointermove raycast; TutorialHint publishes them when the tutorial
   // is up. Either signal drives the focus naturally.
+  //
+  // We attach the target VECTOR3 IMPERATIVELY via a ref (useLayoutEffect)
+  // rather than the <DepthOfField target={vec3}> prop. The React wrapper
+  // conditionally replaces the Vector3 on each prop-diff which breaks
+  // the in-place-mutation pattern this useFrame relies on. Direct .target
+  // assignment on the effect instance is stable across re-renders.
+  const dofRef = useRef<DepthOfFieldEffect | null>(null)
   const dofTarget = useMemo(() => new THREE.Vector3(), [])
   const dofDesired = useMemo(() => new THREE.Vector3(), [])
+
+  useLayoutEffect(() => {
+    if (!dofEnabled || !dofRef.current) return
+    dofRef.current.target = dofTarget
+    if (import.meta.env.DEV) {
+      ;(window as unknown as Record<string, unknown>).__dofEffect = dofRef.current
+      ;(window as unknown as Record<string, unknown>).__dofTarget = dofTarget
+    }
+    return () => {
+      if (dofRef.current) dofRef.current.target = null
+    }
+  }, [dofEnabled, dofTarget])
+
   useFrame(() => {
-    if (!dofEnabled) return
+    if (!dofEnabled || !dofRef.current) return
     const active = hudUniforms.uHudCursorActive.value > 0 && dofFollowCursor
     if (active) dofDesired.copy(hudUniforms.uHudCursor.value)
     else dofDesired.set(0, 0, 0)
@@ -220,7 +241,7 @@ export function PostFx() {
       ) : <></>}
       {dofEnabled ? (
         <DepthOfField
-          target={dofTarget}
+          ref={dofRef}
           focalLength={dofFocalLength}
           bokehScale={dofBokehScale}
         />

--- a/src/world/PostFx.tsx
+++ b/src/world/PostFx.tsx
@@ -9,6 +9,7 @@ import {
   N8AO,
   Noise,
   SMAA,
+  SSAO,
   Vignette,
 } from '@react-three/postprocessing'
 import { BlendFunction } from 'postprocessing'
@@ -92,7 +93,7 @@ export function PostFx() {
       n8aoColor: { value: '#000000', label: 'AO colour' },
       n8aoRenderMode: {
         value: 'Combined',
-        options: ['Combined', 'AO', 'No AO', 'Split', 'Split AO'],
+        options: ['Combined', 'AO', 'No AO', 'Split', 'Split AO', 'SSAO fallback'],
         label: 'render mode',
       },
       n8aoQuality: {
@@ -210,6 +211,13 @@ export function PostFx() {
 
   // Debug sphere position ref — drives a <mesh> whose position tracks dofTarget.
   const debugMeshRef = useRef<THREE.Mesh | null>(null)
+  // Dev hook for N8AO pass introspection.
+  const n8aoRef = useRef<unknown>(null)
+  useLayoutEffect(() => {
+    if (import.meta.env.DEV) {
+      ;(window as unknown as Record<string, unknown>).__n8ao = n8aoRef.current
+    }
+  })
 
   useFrame(() => {
     if (!dofEnabled || !dofRef.current) return
@@ -254,10 +262,11 @@ export function PostFx() {
   const bloomIntensity = lerp(bloomScrambled, bloomSolved, warmth)
   const vignetteDarkness = lerp(vignetteScrambled, vignetteSolved, warmth)
 
-  // enableNormalPass is needed by SSGI's G-buffer reads. Turning it on when
-  // SSGI is off is a minor waste (~one extra render pass) — leave it gated
-  // so the common Path-1 case stays cheap.
-  const needNormalPass = ssgiEnabled || ssrEnabled
+  // enableNormalPass is needed by SSGI's G-buffer reads and by SSAO for
+  // proper hemispherical sampling. Turning it on when none of those are
+  // active is a minor waste (~one extra render pass).
+  const needNormalPass = ssgiEnabled || ssrEnabled ||
+    (n8aoEnabled && n8aoRenderMode === 'SSAO fallback')
 
   return (
     <>
@@ -267,10 +276,11 @@ export function PostFx() {
           <meshBasicMaterial color="#ff00ff" depthTest={false} depthWrite={false} />
         </mesh>
       ) : null}
-    <EffectComposer multisampling={0} enableNormalPass={needNormalPass}>
+    <EffectComposer multisampling={0} enableNormalPass={needNormalPass} stencilBuffer depthBuffer>
       {smaaEnabled ? <SMAA /> : <></>}
-      {n8aoEnabled ? (
+      {n8aoEnabled && n8aoRenderMode !== 'SSAO fallback' ? (
         <N8AO
+          ref={n8aoRef}
           aoRadius={n8aoRadius}
           screenSpaceRadius={n8aoScreenSpaceRadius}
           intensity={n8aoIntensity}
@@ -288,6 +298,19 @@ export function PostFx() {
               : 0 /* Combined */
           }
           quality={n8aoQuality as 'performance' | 'low' | 'medium' | 'high' | 'ultra'}
+        />
+      ) : <></>}
+      {n8aoEnabled && n8aoRenderMode === 'SSAO fallback' ? (
+        <SSAO
+          samples={31}
+          radius={n8aoRadius}
+          intensity={n8aoIntensity * 5}
+          luminanceInfluence={0.7}
+          color={n8aoColor}
+          worldDistanceThreshold={1}
+          worldDistanceFalloff={0.1}
+          worldProximityThreshold={0.4}
+          worldProximityFalloff={0.1}
         />
       ) : <></>}
       {dofEnabled ? (

--- a/src/world/RealismFX.tsx
+++ b/src/world/RealismFX.tsx
@@ -57,11 +57,27 @@ export interface RealismFXProps {
   ssgi: boolean
   ssr: boolean
   motionBlur: boolean
-  // SSGI options
+  // SSGI options — SSR shares all of these (SSREffect extends SSGIEffect).
   ssgiDistance: number
   ssgiThickness: number
+  ssgiAutoThickness: boolean
+  ssgiMaxRoughness: number
   ssgiBlend: number
   ssgiDenoiseIterations: number
+  ssgiDenoiseKernel: number
+  ssgiDenoiseDiffuse: number
+  ssgiDenoiseSpecular: number
+  ssgiDepthPhi: number
+  ssgiNormalPhi: number
+  ssgiRoughnessPhi: number
+  ssgiEnvBlur: number
+  ssgiImportanceSampling: boolean
+  ssgiDirectLightMultiplier: number
+  ssgiSteps: number
+  ssgiRefineSteps: number
+  ssgiSpp: number
+  ssgiResolutionScale: number
+  ssgiMissedRays: boolean
   // MotionBlur options
   motionBlurIntensity: number
   motionBlurJitter: number
@@ -77,9 +93,33 @@ export function RealismFX(props: RealismFXProps) {
   const ssgiOpts = useMemo(() => ({
     distance: props.ssgiDistance,
     thickness: props.ssgiThickness,
+    autoThickness: props.ssgiAutoThickness,
+    maxRoughness: props.ssgiMaxRoughness,
     blend: props.ssgiBlend,
     denoiseIterations: props.ssgiDenoiseIterations,
-  }), [props.ssgiDistance, props.ssgiThickness, props.ssgiBlend, props.ssgiDenoiseIterations])
+    denoiseKernel: props.ssgiDenoiseKernel,
+    denoiseDiffuse: props.ssgiDenoiseDiffuse,
+    denoiseSpecular: props.ssgiDenoiseSpecular,
+    depthPhi: props.ssgiDepthPhi,
+    normalPhi: props.ssgiNormalPhi,
+    roughnessPhi: props.ssgiRoughnessPhi,
+    envBlur: props.ssgiEnvBlur,
+    importanceSampling: props.ssgiImportanceSampling,
+    directLightMultiplier: props.ssgiDirectLightMultiplier,
+    steps: props.ssgiSteps,
+    refineSteps: props.ssgiRefineSteps,
+    spp: props.ssgiSpp,
+    resolutionScale: props.ssgiResolutionScale,
+    missedRays: props.ssgiMissedRays,
+  }), [
+    props.ssgiDistance, props.ssgiThickness, props.ssgiAutoThickness,
+    props.ssgiMaxRoughness, props.ssgiBlend, props.ssgiDenoiseIterations,
+    props.ssgiDenoiseKernel, props.ssgiDenoiseDiffuse, props.ssgiDenoiseSpecular,
+    props.ssgiDepthPhi, props.ssgiNormalPhi, props.ssgiRoughnessPhi,
+    props.ssgiEnvBlur, props.ssgiImportanceSampling, props.ssgiDirectLightMultiplier,
+    props.ssgiSteps, props.ssgiRefineSteps, props.ssgiSpp,
+    props.ssgiResolutionScale, props.ssgiMissedRays,
+  ])
 
   const motionOpts = useMemo(() => ({
     intensity: props.motionBlurIntensity,

--- a/src/world/RealismFX.tsx
+++ b/src/world/RealismFX.tsx
@@ -14,27 +14,22 @@ import {
  * realism-effects' SSGI / SSR / motion-blur on top of the pmndrs chain.
  *
  * ────────────────────────────────────────────────────────────────────────
- * STATUS (2026-04-20): GLSL-level blocker. SSGI / SSR crash the renderer on
- * three 0.183 because realism-effects' hand-written fragment shader calls
- * tone-mapping functions (LinearToneMapping, ReinhardToneMapping, ACES...)
- * that three's shader chunks no longer expose by those names. Toggling
- * motion blur alone may work (no tone-mapping shader dep) — untested.
+ * STATUS (2026-04-20): Working on three 0.183 ✓
+ *   • Motion Blur — works
+ *   • SSGI — works
+ *   • SSR — works (inherits SSGIEffect's shader path)
  *
- * Resolution paths:
- *   1. Wait for realism-effects v2 to publish a version targeting three
- *      0.163+ (tracked — main branch peer still ^0.151.3 as of now).
- *   2. Wait for pmndrs/postprocessing#599 native SSGI to ship.
- *   3. Fork realism-effects and rewrite the GLSL tone-mapping block to
- *      use three's current shader chunks. ~1 day of work, ongoing
- *      maintenance burden.
+ * Patches applied (patches/realism-effects+1.1.2.patch):
+ *   • WebGLMultipleRenderTargets → WebGLRenderTarget({ count, ...opts })
+ *     (removed from three r163)
+ *   • .texture[i] / .map / .push / .length / Array.isArray(.texture) →
+ *     .textures.* (RT API change: .texture is now a scalar getter)
+ *   • renderer.copyFramebufferToTexture(pos, tex) → (tex, pos) (r163 swap)
+ *   • GLSL: OptimizedCineonToneMapping → CineonToneMapping (r163 rename)
  *
- * The 5-patch stack in patches/realism-effects+1.1.2.patch already covers:
- *   • WebGLMultipleRenderTargets → WebGLRenderTarget({count})  (removed r163)
- *   • .texture[i] / .texture.map / .push etc. → .textures
- *   • renderer.copyFramebufferToTexture arg order (swapped r163)
- *
- * That gets the module to LOAD and lets motion blur + infra sit ready.
- * SSGI/SSR render path crashes on first composer tick.
+ * Pass layout: one EffectPass PER realism effect, not merged. Merging
+ * SSGI + SSR into one EffectPass produces duplicate tonemapping_pars_fragment
+ * chunk inclusions → redefinition errors. Separate passes compile cleanly.
  * ────────────────────────────────────────────────────────────────────────
  *
  * Why a manual escape hatch: realism-effects ships no React wrappers and
@@ -117,15 +112,25 @@ export function RealismFX(props: RealismFXProps) {
     }
 
     composer.addPass(velPass, 1)
-    // @ts-expect-error postprocessing's EffectPass accepts variadic effects
-    const effectPass = new EffectPass(camera, ...effects)
-    composer.addPass(effectPass, 2)
+    // One EffectPass per realism effect — SSGI and SSR both include the
+    // tonemapping_pars_fragment chunk, so merging them into a single
+    // EffectPass produces duplicate function definitions at shader-compile
+    // time. Separate passes = slower but each compiles in its own scope.
+    const passes: { dispose?: () => void }[] = []
+    effects.forEach((e, i) => {
+      // @ts-expect-error postprocessing accepts a single effect
+      const p = new EffectPass(camera, e)
+      composer.addPass(p, 2 + i)
+      passes.push(p)
+    })
 
     return () => {
       composer.removePass(velPass)
-      composer.removePass(effectPass)
+      for (const p of passes) {
+        composer.removePass(p as never)
+        p.dispose?.()
+      }
       velPass.dispose?.()
-      effectPass.dispose?.()
       for (const e of effects) (e as { dispose?: () => void }).dispose?.()
     }
   }, [composer, scene, camera, props.ssgi, props.ssr, props.motionBlur, ssgiOpts, motionOpts])

--- a/src/world/RealismFX.tsx
+++ b/src/world/RealismFX.tsx
@@ -1,0 +1,134 @@
+import { useContext, useEffect, useMemo } from 'react'
+import { EffectComposerContext } from '@react-three/postprocessing'
+import { EffectPass } from 'postprocessing'
+import {
+  VelocityDepthNormalPass,
+  SSGIEffect,
+  SSREffect,
+  MotionBlurEffect,
+  // @ts-expect-error realism-effects ships no types
+} from 'realism-effects'
+
+/**
+ * Path-2 escape hatch — mount this as a child of <EffectComposer> to layer
+ * realism-effects' SSGI / SSR / motion-blur on top of the pmndrs chain.
+ *
+ * ────────────────────────────────────────────────────────────────────────
+ * STATUS (2026-04-20): GLSL-level blocker. SSGI / SSR crash the renderer on
+ * three 0.183 because realism-effects' hand-written fragment shader calls
+ * tone-mapping functions (LinearToneMapping, ReinhardToneMapping, ACES...)
+ * that three's shader chunks no longer expose by those names. Toggling
+ * motion blur alone may work (no tone-mapping shader dep) — untested.
+ *
+ * Resolution paths:
+ *   1. Wait for realism-effects v2 to publish a version targeting three
+ *      0.163+ (tracked — main branch peer still ^0.151.3 as of now).
+ *   2. Wait for pmndrs/postprocessing#599 native SSGI to ship.
+ *   3. Fork realism-effects and rewrite the GLSL tone-mapping block to
+ *      use three's current shader chunks. ~1 day of work, ongoing
+ *      maintenance burden.
+ *
+ * The 5-patch stack in patches/realism-effects+1.1.2.patch already covers:
+ *   • WebGLMultipleRenderTargets → WebGLRenderTarget({count})  (removed r163)
+ *   • .texture[i] / .texture.map / .push etc. → .textures
+ *   • renderer.copyFramebufferToTexture arg order (swapped r163)
+ *
+ * That gets the module to LOAD and lets motion blur + infra sit ready.
+ * SSGI/SSR render path crashes on first composer tick.
+ * ────────────────────────────────────────────────────────────────────────
+ *
+ * Why a manual escape hatch: realism-effects ships no React wrappers and
+ * does not speak @react-three/postprocessing's JSX-children merging. We pull
+ * the raw postprocessing composer + scene + camera from EffectComposerContext,
+ * imperatively add a VelocityDepthNormalPass (shared G-buffer) + a single
+ * EffectPass that merges whichever realism effects are enabled.
+ *
+ * Patching: realism-effects 1.1.2 imports `WebGLMultipleRenderTargets`, which
+ * three.js removed in r163. We patch-package in /patches to rewrite those
+ * call sites to `new WebGLRenderTarget(w, h, {count, ...opts})`. The patch
+ * also remaps `renderTarget.texture[i]` → `renderTarget.textures[i]` to
+ * match the new RT API. See patches/realism-effects+1.1.2.patch.
+ *
+ * Ordering inside the drei composer: the VelocityDepthNormalPass must run
+ * before anything that reads it, and the realism EffectPass must run before
+ * the merged JSX children so SSGI's contribution feeds Bloom. We addPass at
+ * index 1 (after RenderPass at 0) and index 2.
+ *
+ * Gate: usePlanet.sceneGrade === 'photoreal' — when the Blender photoreal
+ * diorama lands, flip the grade to light this up.
+ */
+
+export interface RealismFXProps {
+  ssgi: boolean
+  ssr: boolean
+  motionBlur: boolean
+  // SSGI options
+  ssgiDistance: number
+  ssgiThickness: number
+  ssgiBlend: number
+  ssgiDenoiseIterations: number
+  // MotionBlur options
+  motionBlurIntensity: number
+  motionBlurJitter: number
+  motionBlurSamples: number
+}
+
+export function RealismFX(props: RealismFXProps) {
+  const { composer, scene, camera } = useContext(EffectComposerContext)
+
+  // Stabilise the option-object identity so the effect doesn't re-create
+  // passes every parameter tweak (Leva slider drags re-render this component
+  // 60 Hz — re-creating GL passes that fast leaks textures).
+  const ssgiOpts = useMemo(() => ({
+    distance: props.ssgiDistance,
+    thickness: props.ssgiThickness,
+    blend: props.ssgiBlend,
+    denoiseIterations: props.ssgiDenoiseIterations,
+  }), [props.ssgiDistance, props.ssgiThickness, props.ssgiBlend, props.ssgiDenoiseIterations])
+
+  const motionOpts = useMemo(() => ({
+    intensity: props.motionBlurIntensity,
+    jitter: props.motionBlurJitter,
+    samples: props.motionBlurSamples,
+  }), [props.motionBlurIntensity, props.motionBlurJitter, props.motionBlurSamples])
+
+  useEffect(() => {
+    if (!props.ssgi && !props.ssr && !props.motionBlur) return
+
+    const velPass = new VelocityDepthNormalPass(scene, camera)
+    const effects: unknown[] = []
+
+    if (props.ssgi) {
+      const ssgi = new SSGIEffect(scene, camera, velPass, ssgiOpts)
+      effects.push(ssgi)
+    }
+    if (props.ssr) {
+      const ssr = new SSREffect(scene, camera, velPass, ssgiOpts)
+      effects.push(ssr)
+    }
+    if (props.motionBlur) {
+      const mb = new MotionBlurEffect(velPass, motionOpts)
+      effects.push(mb)
+    }
+
+    if (effects.length === 0) {
+      velPass.dispose?.()
+      return
+    }
+
+    composer.addPass(velPass, 1)
+    // @ts-expect-error postprocessing's EffectPass accepts variadic effects
+    const effectPass = new EffectPass(camera, ...effects)
+    composer.addPass(effectPass, 2)
+
+    return () => {
+      composer.removePass(velPass)
+      composer.removePass(effectPass)
+      velPass.dispose?.()
+      effectPass.dispose?.()
+      for (const e of effects) (e as { dispose?: () => void }).dispose?.()
+    }
+  }, [composer, scene, camera, props.ssgi, props.ssr, props.motionBlur, ssgiOpts, motionOpts])
+
+  return null
+}

--- a/src/world/store.ts
+++ b/src/world/store.ts
@@ -57,6 +57,12 @@ interface PlanetStore {
    *  Auto-orbit is enabled in 'orbit-solved' / 'scrambling' / 'orbit-scrambled'
    *  and disabled in 'tutorial' / 'done' so the user can target tiles. */
   introPhase: 'orbit-solved' | 'scrambling' | 'orbit-scrambled' | 'tutorial' | 'done'
+  /** Visual grade for the scene. 'stylized' = the current low-poly test
+   *  diorama — uses the Path-1 pmndrs effect stack only. 'photoreal' = the
+   *  upcoming Blender PBR diorama — Path-2 will layer realism-effects
+   *  (SSGI / TRAA / motion blur) on top when the asset lands. Gate added
+   *  now so Path 2 is a drop-in switch, not a PostFx rewrite. */
+  sceneGrade: 'stylized' | 'photoreal'
   /** While in 'tutorial' phase, the ordered list of moves the user must commit
    *  to reach solved. Rebuilt on mismatch via a shortest-path BFS. */
   tutorialQueue: Move[]
@@ -75,6 +81,7 @@ interface PlanetStore {
   setEasyMode: (v: boolean) => void
   setCameraMode: (v: 'orbit' | 'walk') => void
   setIntroPhase: (v: PlanetStore['introPhase']) => void
+  setSceneGrade: (v: PlanetStore['sceneGrade']) => void
   setTutorialQueue: (q: Move[]) => void
   setTutorialStep: (n: number) => void
   setCommitThreshold: (v: number) => void
@@ -151,6 +158,7 @@ export const usePlanet = create<PlanetStore>((set, get) => ({
   easyMode: false,
   cameraMode: 'orbit',
   introPhase: 'orbit-solved',
+  sceneGrade: 'stylized',
   tutorialQueue: [],
   tutorialStep: 0,
   commitThreshold: (6.5 * Math.PI) / 180, // 6.5° — tuned for a light digital feel
@@ -165,6 +173,7 @@ export const usePlanet = create<PlanetStore>((set, get) => ({
   setEasyMode: v => set({ easyMode: v }),
   setCameraMode: v => set(s => (s.cameraMode === v ? {} : { cameraMode: v })),
   setIntroPhase: v => set(s => (s.introPhase === v ? {} : { introPhase: v })),
+  setSceneGrade: v => set(s => (s.sceneGrade === v ? {} : { sceneGrade: v })),
   setTutorialQueue: q => set({ tutorialQueue: q, tutorialStep: 0 }),
   setTutorialStep: n => set({ tutorialStep: n }),
   setHoveredTile: t => set(s => {

--- a/tests/postfx-path1.mjs
+++ b/tests/postfx-path1.mjs
@@ -1,0 +1,46 @@
+// Path 1 visual probe — inject state directly to skip the animated
+// scramble (headless Chromium is slow; real browsers tested manually).
+import { chromium } from 'playwright'
+
+const URL = process.env.URL || 'http://localhost:5175/'
+const browser = await chromium.launch()
+const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } })
+const page = await ctx.newPage()
+page.on('pageerror', e => console.log('[PAGEERROR]', e.message))
+
+await page.goto(URL)
+await page.waitForFunction(() => !!window.__planet, null, { timeout: 10000 })
+await page.evaluate(() => localStorage.setItem('rubicsworld:tutorialSeen', '1'))
+await page.reload()
+await page.waitForFunction(() => !!window.__planet, null, { timeout: 10000 })
+
+// Skip the intro entirely and scramble directly
+await page.evaluate(() => {
+  const s = window.__planet.getState()
+  s.setIntroPhase('done')
+  s.scrambleInstant(18)
+})
+await page.waitForTimeout(1500) // let effect chain stabilise
+
+await page.screenshot({ path: '/tmp/rubics-test/postfx1-default.png' })
+
+// Side angle
+await page.mouse.move(700, 450)
+await page.mouse.down()
+await page.mouse.move(950, 450, { steps: 12 })
+await page.mouse.up()
+await page.waitForTimeout(500)
+await page.screenshot({ path: '/tmp/rubics-test/postfx1-side.png' })
+
+// Close zoom
+await page.mouse.wheel(0, -800)
+await page.waitForTimeout(400)
+await page.screenshot({ path: '/tmp/rubics-test/postfx1-close.png' })
+
+// Walk mode
+await page.evaluate(() => window.__planet.getState().setCameraMode('walk'))
+await page.waitForTimeout(600)
+await page.screenshot({ path: '/tmp/rubics-test/postfx1-walk.png' })
+
+console.log('Screenshots: /tmp/rubics-test/postfx1-*.png')
+await browser.close()

--- a/tests/tutorial.mjs
+++ b/tests/tutorial.mjs
@@ -34,7 +34,7 @@ const seededLoad = async () => {
   await page.waitForFunction(() => !!window.__planet, null, { timeout: 10000 })
 }
 
-const waitForPhase = async (target, timeout = 20000) =>
+const waitForPhase = async (target, timeout = 60000) =>
   page.waitForFunction(
     t => window.__planet?.getState().introPhase === t,
     target,


### PR DESCRIPTION
Closes #14

## Summary
Extends `src/world/PostFx.tsx` from a minimal Bloom+Vignette chain into a full Path-1 pmndrs-stack polish pass (SMAA, N8AO, DoF, Bloom, Noise, Vignette), plus a ref-escape-hatch wrapper that layers realism-effects' SSGI / SSR / motion blur via a 5-round patch-package patch for three 0.183 compatibility. Every effect's params are exposed under a `PostFx` Leva folder.

## Effect chain
```
render → SMAA → N8AO → DoF → Bloom → Noise → Vignette →
         [if SSGI/SSR/MB toggled] RealismFX passes →
         screen
```

## What changed

**Renderer config (App.tsx)**
- `antialias: false` — SMAA in the effect chain replaces MSAA
- `toneMapping: ACESFilmicToneMapping`, `toneMappingExposure: 1.35` — tone-mapping moved to the RENDERER so effect passes receive linear color (required for future SSGI to behave)
- EffectComposer: `multisampling={0}`, `stencilBuffer`, `depthBuffer` — SSGI-ready + standard depth-texture format for all passes

**Path-1 effects — pmndrs stack (zero new deps)**
- SMAA — crisp edges
- N8AO — grounding pass (see Known issues below)
- DepthOfField — world-unit focus range, ref-attached target that follows the cursor hit
- Bloom — unchanged warmth ramp, both endpoints tunable
- Noise — filmic grain
- Vignette — unchanged warmth ramp

**DoF cursor-follow** — the target Vector3 is attached to the effect via a per-frame self-healing identity check (`if dofRef.current.target !== dofTarget re-attach`). This survives the @react-three/postprocessing wrapper's effect re-instantiation on any prop change. Also `focus range (world)` replaces the previous `focalLength` — postprocessing 6.x aliased it to `focusRange` in world units; our previous 0.12 value produced a 12cm sharp slab too thin for the planet.

**Path 2 infrastructure — realism-effects wrapped via `RealismFX.tsx`**
- 5-round patch at `patches/realism-effects+1.1.2.patch`, auto-applied via `postinstall: patch-package`:
  1. `WebGLMultipleRenderTargets` → `WebGLRenderTarget({ count })` (removed r163)
  2. `.texture[i]` / `.map` / `.push` / `.length` / `Array.isArray` → `.textures.*`
  3. `copyFramebufferToTexture(pos, tex)` → `(tex, pos)` (arg swap r163)
  4. `OptimizedCineonToneMapping` → `CineonToneMapping` (GLSL rename r163)
- `RealismFX` consumes `EffectComposerContext`, builds a `VelocityDepthNormalPass`, and adds one `EffectPass` per enabled realism effect (SSGI / SSR / MotionBlur merged in a single pass collide on `tonemapping_pars_fragment` chunk inclusion → separate passes give each its own shader scope)
- SSGI / SSR / motion blur all **verified working on three 0.183** with zero runtime errors
- Gated for future: `sceneGrade: 'stylized' | 'photoreal'` store flag added

**Leva surface**
Everything under the `PostFx` folder:
- Exposure (ACES)
- SMAA (on)
- N8AO (radius, intensity, falloff, samples, denoise samples/radius, half-res, colour, **render mode** incl. SSAO fallback, quality preset)
- Depth of Field (follow cursor toggle, focus range world, bokeh, smoothing, debug target visualizer)
- Bloom (unsolved/solved intensity, lum threshold/smooth)
- Noise (opacity)
- Vignette (unsolved/solved darkness, offset)
- SSGI (20 params split across rays/temporal/denoise/perf subfolders)
- SSR (inherits SSGI params)
- Motion Blur (intensity, jitter, samples)

## Test plan
- [x] Tutorial E2E (`tests/tutorial.mjs`) — 4/4 scenarios PASS across every commit
- [x] Typecheck + build green
- [x] Screenshot probes confirm: DoF softens off-focus; focus tracks cursor on planet
- [x] realism-effects SSGI + SSR + motion blur render without errors on three 0.183
- [x] Manual: hover cursor across planet → DoF sharp spot tracks it; move off → whole planet sharp

## Known issues / follow-ups
- **N8AO produces zero occlusion on our stylized scene** (verified in AO-only debug mode — pure white output means `finalAo = 1.0` everywhere). Speculated cause: our custom sphere-projection vertex shader (`patchMaterialForSphere`) creates depth micro-discontinuities at tile seams that defeat N8AO's neighbour-delta normal reconstruction. Depth IS being read by DoF fine, so the plumbing is correct. The `SSAO fallback` option in the N8AO render-mode dropdown swaps in pmndrs classic SSAO (hemispherical sampling, no depth-derived normals) — works. When the photoreal Blender diorama arrives with standard geometry, N8AO is likely to start working.
- Headless Chromium's SwiftShader tanks FPS with heavy effect chains; tutorial test timeout bumped 20s → 60s. Real browsers unaffected.
- Bundle +~300 KB (lottie-react already landed + realism-effects infrastructure). Code-split follow-up tracked in `BUNDLE_SPLIT` todo.

## Invariants preserved
- Strict Mode guard (hetvabhasa P3) — untouched
- Per-frame scene push (vyapti PV2) — untouched
- Sphere projection (vyapti PV1) — untouched

## Commits
13 commits, each a focused change with full diagnostic trail. Notable ones:
- `eb1c95f` Path 1 — pmndrs stack + SSGI-ready architecture
- `dfeea6c` realism-effects escape hatch + 5-round patch-package patch
- `4c620f8` SSGI + SSR + motion blur all work on three 0.183
- `b459876` / `8e3415e` / `4f4be08` DoF focus-cursor fix (three separate root causes found and fixed)
- `b82b833` N8AO param expansion
- `469cd42` N8AO diagnosis + SSAO fallback