### PR TITLE
Fix TS errors blocking Vercel prod build

### DIFF
--- a/src/DOFtest.tsx
+++ b/src/DOFtest.tsx
@@ -18,16 +18,6 @@ import type { DepthOfFieldEffect } from 'postprocessing'
  * pattern or in the composite-depth integration.
  */
 
-function DofRefProbe({
-  onRef,
-}: {
-  onRef: (e: DepthOfFieldEffect | null) => void
-}) {
-  const dofRef = useRef<DepthOfFieldEffect | null>(null)
-  useEffect(() => { onRef(dofRef.current) }, [onRef])
-  return null
-}
-
 export function DOFTest() {
   const { focusDistance, focusRange, bokehScale, showBloom } = useControls('DoF', {
     focusDistance: { value: 8, min: 0.1, max: 30, step: 0.1, label: 'focusDistance (m)' },

--- a/src/world/CubeSphere.tsx
+++ b/src/world/CubeSphere.tsx
@@ -22,6 +22,14 @@ const AXIS_TUPLE: Record<Axis, [number, number, number]> = {
   z: [0, 0, 1],
 }
 
+// @react-spring's `animated.meshStandardMaterial` + R3F's overloaded JSX
+// types trip TS2589 (instantiation excessively deep) at the usage site.
+// Aliasing through an `any`-typed binding short-circuits the inference chain
+// without changing runtime behavior — same element, same props, same
+// everything at runtime; TS just stops trying to unify the full prop set.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const AnimatedMaterial: any = animated.meshStandardMaterial
+
 function TileLabel({ homePos, id }: { homePos: THREE.Vector3; id: number }) {
   const ref = useRef<THREE.Group>(null)
   const { camera } = useThree()
@@ -97,7 +105,7 @@ function TileMesh({
             binds the texture to a USE_MAP-less shader — which silently
             ignores it. Remount is cheap (three.js pooled material creation)
             and sidesteps the needsUpdate dance entirely. */}
-        <animated.meshStandardMaterial
+        <AnimatedMaterial
           key={grassMap ? 'grass' : 'plain'}
           color={grassMap ? '#ffffff' : geom.color}
           map={grassMap}

--- a/src/world/GrassPanel.tsx
+++ b/src/world/GrassPanel.tsx
@@ -25,13 +25,6 @@ function triggerDownload(dataUrl: string, filename: string) {
   document.body.removeChild(a)
 }
 
-async function blobToDataUrl(blob: Blob): Promise<string> {
-  return new Promise(resolve => {
-    const r = new FileReader()
-    r.onloadend = () => resolve(r.result as string)
-    r.readAsDataURL(blob)
-  })
-}
 
 /** Render a clean black-and-white mask of the density map: white = allowed,
  *  black = out-of-bounds or inside a prop exclusion. Same coordinate space as


### PR DESCRIPTION
## Summary

Three pre-existing TypeScript errors surfaced only under production \`tsc -b\`, failing the Vercel deploy of #16's merge. Dev HMR was tolerating them.

**Errors (all blocking \`npm run build\`):**
- \`src/DOFtest.tsx\` TS6133 — dead \`DofRefProbe\` helper (leftover from DoF-diagnostic session).
- \`src/world/CubeSphere.tsx\` TS2589 — \`animated.meshStandardMaterial\` trips "type instantiation too deep" via @react-spring + R3F overloaded JSX signatures.
- \`src/world/GrassPanel.tsx\` TS6133 — dead \`blobToDataUrl\` helper.

**Fixes:**
- Remove \`DofRefProbe\`; keep \`useRef\`/\`useEffect\`/\`DepthOfFieldEffect\` imports since the main \`DOFTest\` still uses them.
- Alias \`animated.meshStandardMaterial\` to an \`any\`-typed module-scope binding \`AnimatedMaterial\`. JSX \`@ts-expect-error\` comments don't propagate through JSX-child syntax for TS2589, so the alias is the cleanest workaround — same element, same props, TS just stops trying to unify the full prop set.
- Remove dead \`blobToDataUrl\`.

## Test plan

- [x] \`npm run build\` completes locally (tsc + vite).
- [ ] Vercel preview deploys successfully once merged.
- [ ] No runtime change — CubeSphere material, DOFtest route, and GrassPanel all behave as before (visual smoke test).