### PR TITLE
Fix: match terrain node by prefix so bake-time accessor renaming actually fires

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -156,10 +156,12 @@ function patchGlbColorAccessorNames(body: Buffer, names: readonly string[]): Buf
     return body
   }
   // Find the terrain mesh by walking nodes — meshes don't carry names
-  // reliably from three.js's exporter, but nodes do.
+  // reliably from three.js's exporter, but nodes do. Match by prefix:
+  // the exporter writes the node name as `terrain_gameasset` (or similar
+  // suffix), not bare `terrain`, so strict equality silently no-oped.
   let terrainMeshIdx = -1
   for (const n of j.nodes ?? []) {
-    if (n.name === 'terrain' && typeof n.mesh === 'number') {
+    if (n.name?.startsWith('terrain') && typeof n.mesh === 'number') {
       terrainMeshIdx = n.mesh
       break
     }


### PR DESCRIPTION
## Summary
- `patchGlbColorAccessorNames` was matching `n.name === 'terrain'` but the exporter writes the node as `terrain_gameasset`, so every Bake → diorama.glb has silently skipped the terrain Color Attribute renaming.
- One-line change: switch to `n.name?.startsWith('terrain')`.

## Verification
- Pre-fix probe against `public/diorama.glb`: exact `'terrain'` match → NOT FOUND.
- Post-fix probe: prefix match resolves `terrain_gameasset → mesh 1`.

## Test plan
- [ ] In dev, click "Bake → diorama.glb" in Leva.
- [ ] Re-import the resulting GLB into Blender.
- [ ] Confirm the terrain mesh's Color Attribute layers are now named \`grass\`, \`flowers\`, \`colliders\` instead of \`Color\`, \`Color.001\`, \`Color.002\`.

Closes #22