### PR TITLE
Fix: force absolute /audio/* paths so non-root routes can load loops

### DIFF
--- a/src/world/audio/bus.ts
+++ b/src/world/audio/bus.ts
@@ -599,12 +599,17 @@ class AudioBus {
   }
 
   private loadBuffer(src: string): Promise<AudioBuffer> {
-    const cached = this.bufferCache.get(src)
+    // Registry entries are public/-relative ("audio/foo.ogg"). Without a
+    // leading slash, fetch resolves them against document.baseURI — fine on
+    // /, broken on /optimize/ where they'd hit /optimize/audio/foo.ogg →
+    // SPA fallback HTML → decodeAudioData EncodingError.
+    const url = src.startsWith('/') ? src : '/' + src
+    const cached = this.bufferCache.get(url)
     if (cached) return cached
     const promise = new Promise<AudioBuffer>((resolve, reject) => {
-      this.audioLoader.load(src, resolve, undefined, reject)
+      this.audioLoader.load(url, resolve, undefined, reject)
     })
-    this.bufferCache.set(src, promise)
+    this.bufferCache.set(url, promise)
     return promise
   }
 


### PR DESCRIPTION
## Summary
- All 8 loop samples were 404ing on \`/optimize/?glb=1\` (and any non-root route) because registry \`src\` paths are relative — \`fetch()\` resolved them against \`/optimize/\` baseURI.
- Vite's dev server returned SPA-fallback HTML for the bad paths; \`decodeAudioData\` correctly rejected HTML with \`EncodingError\`.
- One-line normalization in \`AudioBus.loadBuffer\`: \`src.startsWith('/') ? src : '/' + src\`.

## Verification
- Pre-fix: \`http://localhost:5173/optimize/audio/theme.ogg\` returned HTML, \`EncodingError\` × 8 in console.
- Post-fix: paths normalize to \`/audio/theme.ogg\`, all 8 loops load cleanly under Playwright smoke. Direct \`decodeAudioData\` on each file confirms the .ogg encoding is valid (Opus-in-Ogg supported by Chromium).

## Test plan
- [ ] Visit \`/optimize/?glb=1\` in dev; confirm zero \`[audio] failed to load loop sample\` warnings.
- [ ] Visit \`/?glb=1\` (root) — must remain working as before.

Closes #25