### PR TITLE
Fix: skip rebuildMeadow when diorama root is empty (suppress spurious '[grass] no ground' error)

### DIFF
--- a/src/diorama/TileGrid.tsx
+++ b/src/diorama/TileGrid.tsx
@@ -1105,6 +1105,15 @@ export function TileGrid({ mode = 'split', bezier }: {
     const rebuildMeadow = () => {
       const diorama = dioramaRef.current
       if (!diorama) return
+      // Glb-path mounts an empty stub root and async-swaps in the loaded
+      // scene. If a Leva mask "apply" fires during that interim — e.g.
+      // applyDefaultGrassMask at panel mount — buildGrass would traverse
+      // the stub, find no terrain, and emit a spurious "no ground" error.
+      // The mask itself was already stashed in grassRefs.activeMask before
+      // this function ran, and loadGlbDiorama reads that to thread it into
+      // its own buildGrass call once the scene arrives. Skipping here is
+      // safe.
+      if (diorama.root.children.length === 0) return
       for (const old of grassRefs.meadowMeshes) {
         old.parent?.remove(old)
         old.geometry.dispose()


### PR DESCRIPTION
## Summary
- Stack trace identified \`applyDefaultGrassMask\` (GrassPanel.tsx) calling \`rebuildWithMask\` during the glb-async interim, when the diorama root is still an empty stub. \`buildGrass\` traversed the stub, found no terrain, errored.
- The mask was already stashed in \`grassRefs.activeMask\` and the load-time \`buildGrass\` (inside \`loadGlbDiorama\`) reads that — so the actual rebuild happens correctly post-load. The early call was wasted work plus a misleading error.
- Fix: \`rebuildMeadow\` bails when \`diorama.root.children.length === 0\`.

## Verification
- Pre-fix: Playwright smoke against \`/optimize/?glb=1\` reproduced the error every load.
- Post-fix: same smoke shows zero \`[grass]\` errors. Material dedup, seam weld, sphere visibility, BatchedMesh batches all green; \`[diorama] recomputed ground normals on "terrain_gameasset"\` confirms grass-related state remains correct.

## Test plan
- [ ] Visit \`/optimize/?glb=1\` in dev; confirm no \`[grass] no ground object is found\` error.
- [ ] Apply a custom grass mask via Leva; grass should still rebuild correctly.
- [ ] \`/?glb=1\` and imperative path remain unaffected.

Closes #27