### PR TITLE
♻️ refactor(batched-mesh): dedup identity-duplicate geometries at caller

### DIFF
--- a/src/diorama/buildBatchedDiorama.ts
+++ b/src/diorama/buildBatchedDiorama.ts
@@ -70,6 +70,34 @@ function isMorphed(geom: THREE.BufferGeometry): boolean {
   return false
 }
 
+/** Sample-based content fingerprint for de-duplicating identical geometries
+ *  WITHIN a buildBatchedDiorama group. Group key already includes attribute
+ *  layout signature, so all members of a group share attribute names, item
+ *  sizes, indexed-or-not. This fingerprint discriminates by content for
+ *  same-layout geometries: index head/mid/tail + per-attribute count and
+ *  head/mid/tail samples. Misses only meshes that agree on all sampled
+ *  points but differ in interior verts — vanishingly rare for real Blender
+ *  exports, and worst-case symptom is one prop visually replacing another
+ *  (loud failure, easy to spot). three.js's BatchedMesh.addGeometry has no
+ *  internal cache (BatchedMesh.js:627 — copies vertex+index data per call),
+ *  so caller-side dedup is the only place to gain. */
+function geomContentFingerprint(geom: THREE.BufferGeometry): string {
+  const parts: (number | string)[] = []
+  const idx = geom.getIndex()
+  parts.push(idx?.count ?? 0)
+  if (idx) {
+    const a = idx.array as ArrayLike<number>
+    parts.push(a[0] ?? 0, a[(a.length / 2) | 0] ?? 0, a[a.length - 1] ?? 0)
+  }
+  const names = Object.keys(geom.attributes).sort()
+  for (const n of names) {
+    const a = geom.attributes[n]
+    const arr = a.array as ArrayLike<number>
+    parts.push(n, a.count, arr[0] ?? 0, arr[(arr.length / 2) | 0] ?? 0, arr[arr.length - 1] ?? 0)
+  }
+  return parts.join(':')
+}
+
 export function buildBatchedDiorama(
   root: THREE.Object3D,
   vis: SphereVisibility,
@@ -141,6 +169,9 @@ export function buildBatchedDiorama(
   const instanceCounts: number[] = []
   const batchedOriginals = new Set<THREE.Mesh>()
   const _m = new THREE.Matrix4()
+  let totalGeomFresh = 0
+  let totalGeomReused = 0
+  let totalVertsSavedReuse = 0
 
   for (const [, g] of groups) {
     const batch = new BatchedMesh(g.items.length, g.vertSum, g.indexSum, g.mat)
@@ -162,20 +193,36 @@ export function buildBatchedDiorama(
 
     const masks = new Uint32Array(g.items.length)
     let nAdded = 0
+    // Per-batch fingerprint→geomId map. BatchedMesh.addGeometry has no
+    // internal cache (BatchedMesh.js:627 — copies vertex+index per call), so
+    // identity-duplicate geometries within this group would otherwise each
+    // reserve their own slot in the merged buffer. Reusing geomId via
+    // addInstance lets all duplicates share one buffer slot — same draw
+    // count (BatchedMesh still issues 1 draw per batch), but smaller merged
+    // vertex buffer and fewer vertex-shader invocations per draw.
+    const fingerprintToGeomId = new Map<string, number>()
     for (const it of g.items) {
       const geom = it.mesh.geometry as THREE.BufferGeometry
-      let geomId: number
-      try {
-        geomId = batch.addGeometry(geom)
-      } catch (e) {
-        // First-fit reservation overrun or attribute mismatch we didn't
-        // catch with the signature check. Drop this instance, keep the
-        // original Mesh visible so it still renders the legacy way.
-        if (import.meta.env?.DEV) {
-          // eslint-disable-next-line no-console
-          console.warn(`[batchedDiorama] addGeometry failed for ${it.mesh.name}:`, e)
+      const fp = geomContentFingerprint(geom)
+      let geomId = fingerprintToGeomId.get(fp)
+      if (geomId === undefined) {
+        try {
+          geomId = batch.addGeometry(geom)
+        } catch (e) {
+          // First-fit reservation overrun or attribute mismatch we didn't
+          // catch with the signature check. Drop this instance, keep the
+          // original Mesh visible so it still renders the legacy way.
+          if (import.meta.env?.DEV) {
+            // eslint-disable-next-line no-console
+            console.warn(`[batchedDiorama] addGeometry failed for ${it.mesh.name}:`, e)
+          }
+          continue
         }
-        continue
+        fingerprintToGeomId.set(fp, geomId)
+        totalGeomFresh++
+      } else {
+        totalGeomReused++
+        totalVertsSavedReuse += geom.attributes.position.count
       }
       const instId = batch.addInstance(geomId)
       _m.copy(rootInv).multiply(it.mesh.matrixWorld)
@@ -199,6 +246,7 @@ export function buildBatchedDiorama(
     // eslint-disable-next-line no-console
     console.log(
       `[batchedDiorama] batches=${draws} instances=${total} ` +
+      `geom=${totalGeomFresh} reused=${totalGeomReused} (-${totalVertsSavedReuse} verts) ` +
       `skipped: animated=${skippedAnimated} multimat=${skippedMultiMat} ` +
       `skinned=${skippedSkinned} collider=${skippedCollider} ` +
       `morph=${skippedMorph} no-tile=${skippedNoTile}`,


### PR DESCRIPTION
## Summary

- `THREE.BatchedMesh.addGeometry` has no internal cache (`BatchedMesh.js:627` — copies vertex+index per call). `buildBatchedDiorama` was calling it once per item, so 122 of 229 instances on the current diorama reserved their own merged-buffer slot for content-identical geometries.
- Fix: per-batch `Map<contentFingerprint, geometryId>`. When a fingerprint matches a prior add in the same batch, reuse via `addInstance(existingId)`.
- Same draw-call count (41 batches × 24 tile passes = 984/frame, unchanged); merged vertex buffer shrinks by ~31k verts on the current scene. Per-instance world transforms remain distinct via `setMatrixAt`.

closes #30

## Why ship despite the small perf delta

Vertex throughput is not the dominant cost on this scene — 60s orbit+zoom A/B (`/tmp/probe-orbit.mjs`):

| Route | render before | render after | Δ |
|---|---|---|---|
| `/optimize/?glb=1` | 7.60 ms | 7.44 ms | -2.1% |
| `/?glb=1` | 15.66 ms | 14.66 ms | -6.4% |

~0.16 ms saved per frame on `/optimize/`, well within run-to-run noise. Shipping primarily as **structural cleanup**: callers of `BatchedMesh.addGeometry` must dedup themselves, this fixes ours. Perf gain is incidental.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` no new warnings/errors in `buildBatchedDiorama.ts` (pre-existing issues elsewhere unchanged)
- [x] DEV load log shows `geom=107 reused=122 (-31091 verts)` on the current `public/diorama.glb`
- [x] `/?glb=1` and `/optimize/?glb=1` both load with no `pageerror`
- [x] FPS stable or up under 60s headed-Chromium orbit+zoom (A: 58.1 → 60.8, B: 108.7 → 110.9)
- [ ] Manual sanity: orbit the planet on `/optimize/?glb=1`, confirm no missing or visually-substituted props (sample-based fingerprint has a vanishingly-small false-dedup risk — symptom would be one prop visually replacing another)

## Caveats

- BatchedMesh constructor still over-reserves vertex/index buffer space (`vertSum`/`indexSum` from the pre-dedup count). After this change those slots are partially unused. Functionally fine; could trim later if memory matters.
- Fingerprint is sample-based, not a full content hash. Within the same `(material.uuid, geometrySignature)` group, the risk of a false match (geometries agree on all sampled points but differ in interior verts) is low for real Blender exports. Worst case is loud and easy to spot.