### PR TITLE
⚡ perf(sphere-cull): per-tile centroid back-face cull at threshold -0.6

### DIFF
--- a/src/diorama/TileGrid.tsx
+++ b/src/diorama/TileGrid.tsx
@@ -1505,18 +1505,23 @@ export function TileGrid({ mode = 'split', bezier }: {
       let optTilesCulled = 0
       if (optimize) {
         // View direction = camera position normalized (planet at origin).
-        // Cull ONLY the strictly-antipodal face. On a sphere the four
-        // "side" faces remain quite visible from any viewing angle —
-        // their content bulges past the limb due to terrain elevation.
-        // So we want a threshold that only fires for tiles whose face
-        // normal points almost exactly opposite the camera. -0.95 is
-        // "true antipodal" (~162° from view dir): axis-aligned camera
-        // culls the one fully-occluded back face (facing=-1); slightly
-        // off-axis releases it the moment elevated content might
-        // re-emerge at the silhouette; corner-of-3 views never cull
-        // (rear-axis faces at facing≈-0.577 escape comfortably).
-        // Earlier value -0.6 was geometrically safe but more aggressive;
-        // -0.95 is the bulletproof setting for elevation-bearing terrain.
+        // Per-tile back-face cull: each tile's centroid direction (= cubePos
+        // normalized) is dotted with optCamDir. The face-normal version was
+        // a coarser proxy — all 4 quadrants on one face shared one normal,
+        // so the threshold had to be absurdly conservative (-0.95) to avoid
+        // culling tiles whose face is mostly visible. Per-tile centroid
+        // discriminates by quadrant; threshold -0.6 is geometrically safe.
+        //
+        // Threshold derivation (data-corroborated, see issue #32):
+        //   - quadrant angular radius from its own centroid ≈ 16°
+        //   - elevation bulge ≈ arctan(maxElevation/sphereRadius) ≈ 17°
+        //   - safe threshold = -sin(16° + 17°) ≈ -0.545
+        //   - chosen -0.6 (~5° margin past safe) for headroom
+        //
+        // Observed in /tmp/probe-facings.out at rest: 4 tiles cluster at
+        // -0.82 (deeply back-facing quadrants), next tier at -0.41 (near
+        // limb, NOT safe to cull). -0.6 cleanly separates the clusters.
+        // Active orbit: 4-6 tiles cull per frame depending on camera pose.
         optCamDir.copy(camera.position).normalize()
         optMat4.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse)
         optFrustum = optFrustumInst.setFromProjectionMatrix(optMat4)
@@ -1528,6 +1533,19 @@ export function TileGrid({ mode = 'split', bezier }: {
         let quaternion = r.quaternion
         let clipPlanes = r.clipPlanes
         let faceNormal = FACES[tile.face].normal
+
+        // Per-tile centroid direction in cube-space — finer-grained than
+        // faceNormal (each face's 4 quadrants share faceNormal but have
+        // distinct centroid directions). cubePos formula matches
+        // storeTileCubeRender's intermediate (kept inline to avoid
+        // plumbing the value through CellRender). CELL=1 baked in.
+        const _f = FACES[tile.face]
+        const _uOff = (tile.u - 0.5)
+        const _vOff = (0.5 - tile.v)
+        let tileCentroidDir = _f.normal.clone()
+          .addScaledVector(_f.right, _uOff)
+          .addScaledVector(_f.up, _vOff)
+          .normalize()
 
         if (sliceQuat && activeAxis && tileInSlice(tile, activeAxis, activeSlice)) {
           // Rotate around origin: position rotates, plane normals rotate,
@@ -1541,17 +1559,18 @@ export function TileGrid({ mode = 'split', bezier }: {
             p.constant,
           ))
           faceNormal = faceNormal.clone().applyQuaternion(sliceQuat)
+          tileCentroidDir = tileCentroidDir.clone().applyQuaternion(sliceQuat)
         }
 
         let cullThisTile = false
         if (optimize && optFrustum) {
-          // Back-face: face-normal vs view-dir. -0.95 threshold = only
-          // strictly-antipodal tiles fire the cull (see setup comment
-          // above for the geometry). Side faces and corner-of-3 rear
-          // faces always escape, so horizon-elevation content stays
-          // intact.
-          const facing = faceNormal.dot(optCamDir)
-          if (facing < -0.95) { cullThisTile = true; optTilesCulled++ }
+          // Back-face: per-tile centroid vs view-dir. Threshold -0.6 culls
+          // tiles whose centroid is at least ~127° from camera direction
+          // (cos⁻¹(-0.6) ≈ 127°), with comfortable margin past the safe
+          // bound -sin(quadrant_half_angle + elevation_bulge) ≈ -0.545.
+          // See setup comment above for the derivation and observed data.
+          const tileFacing = tileCentroidDir.dot(optCamDir)
+          if (tileFacing < -0.6) { cullThisTile = true; optTilesCulled++ }
           // Frustum: tile's projected sphere centre is faceNormal direction
           // (the tile spans ~half a face → ~0.5 rad on the unit sphere;
           // bound radius 0.7 in world units gives slack for tall meshes).


### PR DESCRIPTION
## Summary

- Existing `faceNormal · optCamDir < -0.95` cull was dormant in every default camera position. faceNormal is a coarser proxy (4 quadrants per face share one normal), so the threshold had to be -0.95 to avoid culling mostly-visible faces. Default orbit (corner-of-3) reaches only ~-0.577 → 0/24 culled.
- Switch to **per-tile centroid direction** (cubePos.normalize()), discriminates by quadrant. Threshold **-0.6** sized from cube/sphere geometry + observed data.
- Threshold-derivation comment in code documents the math; data sample at `/tmp/probe-facings.out`.

closes #32

## Effect (measured)

60s headed-Chromium orbit+zoom A/B on `/optimize/?glb=1` (`/tmp/probe-orbit.mjs`):

| Metric | post-#31 baseline | this PR | Δ |
|---|---|---|---|
| **tilesDrawn** | 24.0/24 | **19.7/24** (min 19, max 20) | -18% |
| **culled** | 0.0/24 | **4.3/24** | (cull active) |
| **render mean** | 7.44 ms | **6.44 ms** | **-13.4%** |
| **loopBody** | 8.15 ms | 7.07 ms | -13.3% |
| **fps mean** | 110.9 | **119.1** | **+7.4%** |

`/?glb=1` (DEFAULT route, no per-tile cull) unaffected within noise.

Cumulative since today's perf detour started:
- baseline (`/optimize/`): 7.60 ms render / 108.7 fps
- after PR #31 + this: 6.44 ms render / 119.1 fps
- total: -15.3% render, +9.6% fps

## Threshold derivation

Geometry-based, data-corroborated:

- Quadrant angular radius from its centroid (sphere-projected): **~16°**
- Elevation bulge: `arctan(maxElevation / sphereRadius) ≈ arctan(0.3) ≈ 17°`
- Safe threshold: `-sin(16° + 17°) ≈ -0.545`
- Chosen: **-0.6** (~5° margin past safe)

Observed at-rest distribution (drag-released, OrbitControls default):
```
[probe OPT     ] tileFacings asc: -0.82 -0.82 -0.82 -0.82  -0.41 ×8  +0.41 ×8  +0.82 ×4
```
-0.6 cleanly separates the deeply-back-facing -0.82 cluster from the near-limb -0.41 tier (which is NOT safe to cull — only 24° past silhouette, less than the ~33° bulge+radius safety margin).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` errors unchanged from main (9 pre-existing audio/Leva)
- [x] DEV probe: `culled=4.3/24` reliably under orbit; no `pageerror`
- [x] FPS up, render-time down on `/optimize/`; DEFAULT unchanged within noise
- [ ] Manual sanity (recommend before merge): orbit `/optimize/?glb=1`, watch for missing tile content at the silhouette during slow rotation. Cull is geometrically conservative; expected outcome is visually-identical with lighter render cost.

## Caveats

- Threshold is content-specific. If `maxElevation` grows past 0.3, threshold may need re-tune. The comment in code is the prompt; methodology is "drop the per-tile facing dump (commit `4370864^` had it), pick the gap between back-cluster and near-limb cluster from observed data."
- The frustum-cull below the back-face cull still uses `faceNormal`-direction sphere centroid. Pre-existing; could be tightened to per-tile in a follow-up.
- Per-tile centroid is computed for both DEFAULT and OPT routes (the cull-firing branch is OPT-only). DEFAULT pays a trivial extra ~0.05 ms/frame; not worth gating to keep the loop body simple.