### PR TITLE
🚀 perf(render): promote /optimize/ render path to default

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,8 +11,9 @@ import { FluidTest } from './FluidTest.tsx'
 //   /DOFtest/   → minimal DoF repro scene
 //   /GrassTest/ → minimal cursor-hover grass repro scene
 //   /bake       → headless diorama → public/diorama.glb commit page
-//   /optimize   → full app + sphere-tile back-face & frustum culling
-//                 (A/B baseline against / to measure perf wins)
+//   /optimize   → historical A/B alias; behaves identically to / since
+//                 the optimized render path was promoted to default
+//                 (closes #36; PK8 probe: 3.1× render, 2.6× fps).
 //   /fluid      → CellFluids 2 FBX viewer — verify per-vertex flow
 //                 channels (UV1/UV2/COLOR_0) before wiring the shader
 //   else        → full app
@@ -20,13 +21,13 @@ const path = typeof window !== 'undefined' ? window.location.pathname.toLowerCas
 const isDofTest   = path.startsWith('/doftest')
 const isGrassTest = path.startsWith('/grasstest')
 const isBake      = path.startsWith('/bake')
-const isOptimize  = path.startsWith('/optimize')
 const isFluid     = path.startsWith('/fluid')
 
-// Module-flag read by TileGrid + others. /optimize/ enables sphere-tile
-// back-face & frustum culling for A/B perf comparison vs default route.
+// Module-flag read by TileGrid: enables BatchedMesh build, per-tile
+// back-face cull, frustum cull. Always on now — was the /optimize/
+// A/B switch (issue #20) before #36 promoted it to default.
 if (typeof window !== 'undefined') {
-  ;(window as unknown as { __rwOptimize?: boolean }).__rwOptimize = isOptimize
+  ;(window as unknown as { __rwOptimize?: boolean }).__rwOptimize = true
 }
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
## Summary

The `/optimize/` route was an A/B switch from the issue #20 era (back when we weren't sure the optimized path was actually faster). Two probes ago it was confirmed faster on every metric. This PR promotes it to default — flipping `__rwOptimize` to `true` unconditionally so every visitor gets the wins from PR #31 (geometry dedup) + PR #33 (per-tile back-face cull).

## Change

Single line in `src/main.tsx`:
```diff
- (window as unknown as { __rwOptimize?: boolean }).__rwOptimize = isOptimize
+ (window as unknown as { __rwOptimize?: boolean }).__rwOptimize = true
```
Plus comment updates documenting that `/optimize/` is now a historical alias.

`isOptimize` is dropped (no longer read). Route comment in main.tsx documents the alias behavior. No other code touched — the optimize branches in `TileGrid.tsx` already drive everything off this flag (build-time `buildBatchedDiorama`, per-frame frustum + cull + `applySphereVisibility`), so flipping the flag propagates the win to every visitor.

## Verification (PK8 probe-orbit, 60s orbit + zoom, `?glb=1`)

| Route | Before flip | After flip | Δ |
|---|---|---|---|
| DEFAULT (`/`) | 21.37ms / 43.7 fps / 24 tiles | 5.69ms / 118.4 fps / 18.1 tiles | **-73% render, +171% fps** |
| OPT (`/optimize/`) | 6.85ms / 111.8 fps / 19.0 tiles | 5.82ms / 115.0 fps / 18.0 tiles | within noise |

Both routes now produce matching numbers within probe noise — the optimize path is the only path.

## Risk audit (dhyana B4)

- **P21/P24 (composite quad ↔ depth-gated post effects):** unchanged. Flag never gated the FBO/composite path.
- **P23 (mesh omission ↔ tree consumers):** `applySphereVisibility` was already running on every probe of `/optimize/`. If it broke a consumer, /optimize/ would already be broken — and it isn't. After PR #28, buildGrass gates on `groundMesh` presence.
- **P46 (relative paths):** route gate untouched; assets already absolute since PR #26.

## Test plan

- [x] `npm run build` clean (308ms)
- [x] PK8 probe-orbit confirms match within noise on both routes
- [x] tilesDrawn/culled stable across the 60s orbit (no flicker)
- [ ] Spot-check in browser: rotate planet, hover tile (grass), trigger audio

closes #36