### PR TITLE
🔬 chore(probe): split per-tile render time into clipSet + mwUpdate + render

### DIFF
--- a/src/diorama/TileGrid.tsx
+++ b/src/diorama/TileGrid.tsx
@@ -58,6 +58,8 @@ const TILE_BACKFACE_CULL_THRESHOLD = -0.9
 const probe = {
   applyVis: 0,        // ms spent in applySphereVisibility per second
   applyBatch: 0,      // ms in applyBatchVisibility per second
+  clipSet: 0,         // ms in `gl.clippingPlanes = ...` per second (Firefox-suspect)
+  mwUpdate: 0,        // ms in updateMatrixWorld per second
   render: 0,          // ms in per-tile gl.render(dScene) per second
   loopTotal: 0,       // ms for the entire per-tile for-loop body per second
   tilesRendered: 0,   // tiles that actually called gl.render per second
@@ -1624,13 +1626,17 @@ export function TileGrid({ mode = 'split', bezier }: {
           // need the per-tile visible=false override that lived here.)
         }
 
+        const _tClip = import.meta.env.DEV ? performance.now() : 0
         gl.clippingPlanes = clipPlanes
+        if (import.meta.env.DEV) probe.clipSet += performance.now() - _tClip
         if (su) su.uFaceNormal.value.copy(faceNormal)
 
         diorama.root.quaternion.copy(quaternion)
         diorama.root.position.copy(position)
         diorama.root.updateMatrix()
+        const _tMW = import.meta.env.DEV ? performance.now() : 0
         diorama.root.updateMatrixWorld(true)
+        if (import.meta.env.DEV) probe.mwUpdate += performance.now() - _tMW
         const _tRender = import.meta.env.DEV ? performance.now() : 0
         gl.render(dScene, camera)
         if (import.meta.env.DEV) {
@@ -1683,12 +1689,16 @@ export function TileGrid({ mode = 'split', bezier }: {
             `culled=${(probe.tilesCulled / f).toFixed(1)}/24 | ` +
             `applyVis=${(probe.applyVis / f).toFixed(2)}ms ` +
             `applyBatch=${(probe.applyBatch / f).toFixed(2)}ms ` +
+            `clipSet=${(probe.clipSet / f).toFixed(2)}ms ` +
+            `mwUpdate=${(probe.mwUpdate / f).toFixed(2)}ms ` +
             `render=${(probe.render / f).toFixed(2)}ms ` +
             `loopBody=${(probe.loopTotal / f).toFixed(2)}ms ` +
             `(${f} frames)`
           )
           probe.applyVis = 0
           probe.applyBatch = 0
+          probe.clipSet = 0
+          probe.mwUpdate = 0
           probe.render = 0
           probe.loopTotal = 0
           probe.tilesRendered = 0


### PR DESCRIPTION
## Summary

DEV-only probe instrumentation upgrade. The existing `[probe ...]` log line bundled all per-tile work into a single `render=Xms` metric — not granular enough to isolate which line of the per-tile loop was the bottleneck on Firefox.

This adds two finer accumulators wrapping the suspect lines:
- `clipSet` — ms in `gl.clippingPlanes = clipPlanes` per second
- `mwUpdate` — ms in `diorama.root.updateMatrixWorld(true)` per second

Both flush into the existing once-per-second probe line. Zero production cost (gated on `import.meta.env.DEV`).

## Diagnostic outcome

Used this to diagnose the Firefox 52 fps gap (vs Chrome 120 fps):

```
[probe probe   ] tilesDrawn=23.0/24 culled=1.0/24 |
  applyVis=0.09ms applyBatch=0.03ms
  clipSet=0.00ms mwUpdate=0.94ms
  render=18.06ms loopBody=19.10ms
```

- `clipSet=0.00ms` rules out the clip-plane assignment as the hot line — three.js does the work lazily inside `gl.render`
- `mwUpdate=0.94ms` is small
- `render=18.06ms` confirms it's per-`gl.render()` dispatch overhead × 24

A separate diagnostic (rendering only the first non-culled tile) measured 1.02ms — confirming an 18× upper bound for a 24→1 rewrite. Tracked in #40.

## Diff

Single file (`src/diorama/TileGrid.tsx`), +10 LOC:
- 2 new fields in `probe` struct
- 2 timer brackets around the suspect lines
- 2 `clipSet=` + `mwUpdate=` tokens in the log line + reset

## Test plan

- [x] `npm run build` clean
- [x] DEV probe lines now show 6 metrics instead of 4
- [x] Production build untouched (DEV-gated)