### PR TITLE
Bézier-curve kernel filter for audio editor (closes #65)

### DIFF
--- a/src/AudioEditorRoute.tsx
+++ b/src/AudioEditorRoute.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import App from './App'
-import { audioBus, type LoopDef, type EventDef, type ParamSpec } from './world/audio/bus'
+import { audioBus, type LoopDef, type EventDef, type ParamSpec, type KernelSpec } from './world/audio/bus'
 import { audioLive, audioBootSlug } from './world/audio/audioLive'
 import { useLastTriggered } from './world/audio/lastTriggered'
 import { ALL_TRIGGERS } from './world/audio/triggers'
@@ -410,6 +410,222 @@ function Inspector({ entry }: { entry: Entry | null }) {
           </>
         : <EventOverrides entry={entry.def} />
       }
+      <KernelEditor entry={entry} />
+    </div>
+  )
+}
+
+// ── KernelEditor — Bézier-curve convolution kernel (#65) ───────────────
+
+const DEFAULT_KERNEL: KernelSpec = {
+  p1:  [0, 0],
+  cp1: [0.1, 1],
+  cp2: [0.4, 0.4],
+  p2:  [1, 0],
+  taps: 256,
+  decay: 3,
+  wet: 0.4,
+}
+
+type CtrlPoint = 'p1' | 'cp1' | 'cp2' | 'p2'
+
+const CANVAS_W = 260
+const CANVAS_H = 110
+const PAD = 8
+const HANDLE_RADIUS = 6
+const HIT_RADIUS = 12
+
+/**
+ * Inspector section that lets the user draw a convolution kernel as a
+ * cubic Bézier. Drag any of the four control points; the bus rebuilds
+ * the impulse-response AudioBuffer on every change so subsequent
+ * triggers (events) or loop attaches use the new kernel.
+ *
+ * Coordinate system: canvas pixel (x, y) ↔ kernel space (u, v) where
+ *   u = (px - PAD) / drawW   ∈ [0..1]
+ *   v = 1 - (py - PAD) / drawH ∈ [0..1]   (canvas y flips)
+ */
+function KernelEditor({ entry }: { entry: Entry }) {
+  // Live state mirrors audioLive's kernel; default fills in if absent.
+  const initialKernel = entry.def.kernel ?? null
+  const [kernel, setKernel] = useState<KernelSpec | null>(initialKernel)
+  const dragRef = useRef<{ which: CtrlPoint; rect: DOMRect } | null>(null)
+
+  // Keep React state in sync if the user switches entries.
+  useEffect(() => {
+    setKernel(entry.def.kernel ?? null)
+  }, [entry.def.key, entry.def.kernel])
+
+  const drawW = CANVAS_W - PAD * 2
+  const drawH = CANVAS_H - PAD * 2
+
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const dpr = window.devicePixelRatio || 1
+    canvas.width = CANVAS_W * dpr
+    canvas.height = CANVAS_H * dpr
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.scale(dpr, dpr)
+    // Background + axes
+    ctx.fillStyle = '#0a0d12'
+    ctx.fillRect(0, 0, CANVAS_W, CANVAS_H)
+    ctx.strokeStyle = '#1e242e'
+    ctx.lineWidth = 1
+    // Zero-amplitude line (mid)
+    ctx.beginPath(); ctx.moveTo(PAD, CANVAS_H - PAD); ctx.lineTo(CANVAS_W - PAD, CANVAS_H - PAD); ctx.stroke()
+    if (!kernel) {
+      ctx.fillStyle = '#5a6270'
+      ctx.font = '11px system-ui'
+      ctx.textAlign = 'center'
+      ctx.fillText('No kernel — Add Kernel below', CANVAS_W / 2, CANVAS_H / 2)
+      return
+    }
+    // Map kernel-space → canvas-space helper
+    const toCanvas = (u: number, v: number): [number, number] => [
+      PAD + u * drawW,
+      PAD + (1 - v) * drawH,
+    ]
+    // Control polygon (faint dashed)
+    ctx.strokeStyle = '#2a323d'
+    ctx.setLineDash([3, 3])
+    ctx.beginPath()
+    const [x0, y0] = toCanvas(...kernel.p1)
+    const [xc1, yc1] = toCanvas(...kernel.cp1)
+    const [xc2, yc2] = toCanvas(...kernel.cp2)
+    const [x1, y1] = toCanvas(...kernel.p2)
+    ctx.moveTo(x0, y0); ctx.lineTo(xc1, yc1)
+    ctx.moveTo(x1, y1); ctx.lineTo(xc2, yc2)
+    ctx.stroke()
+    ctx.setLineDash([])
+    // Curve
+    ctx.strokeStyle = '#4a8eef'
+    ctx.lineWidth = 2
+    ctx.beginPath()
+    ctx.moveTo(x0, y0)
+    ctx.bezierCurveTo(xc1, yc1, xc2, yc2, x1, y1)
+    ctx.stroke()
+    // Decay envelope (so user sees the actual IR shape after exp decay)
+    if (kernel.decay > 0) {
+      ctx.strokeStyle = 'rgba(200, 80, 80, 0.6)'
+      ctx.lineWidth = 1
+      ctx.beginPath()
+      const N = 64
+      for (let i = 0; i <= N; i++) {
+        const t = i / N
+        const env = Math.exp(-kernel.decay * t)
+        const [px, py] = toCanvas(t, env)
+        if (i === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py)
+      }
+      ctx.stroke()
+    }
+    // Anchors + handles
+    const drawDot = (x: number, y: number, kind: 'anchor' | 'handle') => {
+      ctx.fillStyle = kind === 'anchor' ? '#cfd6e0' : '#4a8eef'
+      ctx.beginPath()
+      ctx.arc(x, y, HANDLE_RADIUS, 0, Math.PI * 2)
+      ctx.fill()
+      ctx.strokeStyle = '#0a0d12'
+      ctx.lineWidth = 2
+      ctx.stroke()
+    }
+    drawDot(x0, y0, 'anchor')
+    drawDot(x1, y1, 'anchor')
+    drawDot(xc1, yc1, 'handle')
+    drawDot(xc2, yc2, 'handle')
+  }, [kernel, drawW, drawH])
+
+  const commitKernel = useCallback((next: KernelSpec) => {
+    setKernel(next)
+    if (entry.kind === 'loop') audioBus.setLoopKernel(entry.def.key, next)
+    else audioBus.setEventKernel(entry.def.key, next)
+    if (entry.kind === 'loop') editedParamKeys.add(entry.def.key)
+    else editedEventKeys.add(entry.def.key)
+  }, [entry])
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    if (!kernel) return
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const rect = canvas.getBoundingClientRect()
+    const px = e.clientX - rect.left
+    const py = e.clientY - rect.top
+    const points: Array<{ key: CtrlPoint; x: number; y: number }> = [
+      { key: 'p1',  x: PAD + kernel.p1[0]  * drawW, y: PAD + (1 - kernel.p1[1])  * drawH },
+      { key: 'p2',  x: PAD + kernel.p2[0]  * drawW, y: PAD + (1 - kernel.p2[1])  * drawH },
+      { key: 'cp1', x: PAD + kernel.cp1[0] * drawW, y: PAD + (1 - kernel.cp1[1]) * drawH },
+      { key: 'cp2', x: PAD + kernel.cp2[0] * drawW, y: PAD + (1 - kernel.cp2[1]) * drawH },
+    ]
+    let hit: CtrlPoint | null = null
+    let bestDist = HIT_RADIUS
+    for (const pt of points) {
+      const d = Math.hypot(pt.x - px, pt.y - py)
+      if (d < bestDist) { bestDist = d; hit = pt.key }
+    }
+    if (!hit) return
+    e.preventDefault()
+    dragRef.current = { which: hit, rect }
+    canvas.setPointerCapture(e.pointerId)
+  }, [kernel, drawW, drawH])
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    const drag = dragRef.current
+    if (!drag || !kernel) return
+    const px = e.clientX - drag.rect.left
+    const py = e.clientY - drag.rect.top
+    // Allow control handles to extend past visible canvas — clamp only
+    // anchors to [0..1]² since they define the kernel's start/end times.
+    const u = (px - PAD) / drawW
+    const v = 1 - (py - PAD) / drawH
+    const isAnchor = drag.which === 'p1' || drag.which === 'p2'
+    const cu = isAnchor ? Math.max(0, Math.min(1, u)) : u
+    const cv = isAnchor ? Math.max(0, Math.min(1, v)) : v
+    commitKernel({ ...kernel, [drag.which]: [cu, cv] })
+  }, [kernel, drawW, drawH, commitKernel])
+
+  const onPointerUp = useCallback((e: React.PointerEvent) => {
+    dragRef.current = null
+    canvasRef.current?.releasePointerCapture(e.pointerId)
+  }, [])
+
+  return (
+    <div style={{ marginTop: 14, paddingTop: 12, borderTop: '1px solid #1e242e' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+        <span style={{ fontSize: 10, opacity: 0.55, textTransform: 'uppercase', letterSpacing: 1 }}>
+          Kernel filter
+        </span>
+        {kernel
+          ? <button onClick={() => {
+              setKernel(null)
+              if (entry.kind === 'loop') audioBus.setLoopKernel(entry.def.key, undefined)
+              else audioBus.setEventKernel(entry.def.key, undefined)
+            }} style={smallBtn}>Remove</button>
+          : <button onClick={() => commitKernel({ ...DEFAULT_KERNEL })} style={smallBtn}>+ Add Kernel</button>
+        }
+      </div>
+      <canvas
+        ref={canvasRef}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        style={{
+          width: CANVAS_W, height: CANVAS_H, display: 'block',
+          borderRadius: 3, background: '#0a0d12',
+          touchAction: 'none', cursor: kernel ? 'pointer' : 'default',
+        }}
+      />
+      {kernel && (
+        <div style={{ marginTop: 8 }}>
+          <Slider label="taps (length)" value={kernel.taps} min={16} max={1024} step={16}
+                  onChange={v => commitKernel({ ...kernel, taps: v })} />
+          <Slider label="decay" value={kernel.decay} min={0} max={20} step={0.1}
+                  onChange={v => commitKernel({ ...kernel, decay: v })} />
+          <Slider label="wet" value={kernel.wet} min={0} max={1} step={0.01}
+                  onChange={v => commitKernel({ ...kernel, wet: v })} />
+        </div>
+      )}
     </div>
   )
 }
@@ -996,6 +1212,9 @@ function buildSparseAudioJson(): { loops?: LoopDef[]; events?: EventDef[] } {
       baked.params = { ...(baked.params ?? def.params ?? {}), vol: { ...(baked.params?.vol ?? def.params?.vol ?? {}), base: baseVol * ovr.vol } }
     }
     if (ovr?.radius != null) baked.radius = ovr.radius
+    // Kernel filter (#65) — persist whatever audioLive has now. Reload
+    // re-applies via boot XHR + setLoopKernel on attach.
+    if (def.kernel) baked.kernel = def.kernel
     loops.push(baked)
   }
   if (loops.length) out.loops = loops
@@ -1009,6 +1228,7 @@ function buildSparseAudioJson(): { loops?: LoopDef[]; events?: EventDef[] } {
     const baked: EventDef = { key: def.key, anchor: def.anchor, src: def.src }
     if (def.pitchJitter != null) baked.pitchJitter = def.pitchJitter
     if (def.polyphony != null) baked.polyphony = def.polyphony
+    if (def.kernel) baked.kernel = def.kernel
     events.push(baked)
   }
   if (events.length) out.events = events

--- a/src/world/audio/bus.ts
+++ b/src/world/audio/bus.ts
@@ -55,6 +55,11 @@ export interface LoopDef {
   key: string
   anchor: AnchorRef
   src: string
+  /** Convolution kernel — Bézier-curve impulse response (#65). For
+   *  loops the kernel applies serially through setFilters; the wet
+   *  factor scales the kernel buffer values, which acts as dry/wet
+   *  mix only if the curve carries an impulse at t=0. */
+  kernel?: KernelSpec
   // New shape: per-param bindings. Common keys:
   //   `vol`     — volume (sample loops via setVolume; synth 2D via synthGain;
   //               synth POSITIONAL via positional setVolume)
@@ -90,6 +95,41 @@ export interface EventDef {
   // Undefined = unlimited (legacy behaviour). Sample events only —
   // synth: voices ignore this for now (they're fire-and-forget).
   polyphony?: number
+  /** Convolution kernel — Bézier-curve-defined impulse response (#65). */
+  kernel?: KernelSpec
+}
+
+/**
+ * Convolution kernel specified by a single cubic Bézier curve in
+ * normalised [0..1]² space (x = time progress 0..1, y = amplitude
+ * 0..1). The bus samples the curve at `taps` points, multiplies by
+ * exp(-decay × t) so the IR doesn't hum forever, and packs the result
+ * into a single-channel AudioBuffer fed to a ConvolverNode.
+ *
+ * Why Bézier (not raw sample list): two anchors + two handles is the
+ * intuitive "draw an attack/decay shape" UI. Storing 4 points (8
+ * floats) commits a tiny audio.json footprint vs. dumping a 256-sample
+ * array per entry.
+ */
+export interface KernelSpec {
+  /** Bézier endpoints + control points, all in [0..1]². */
+  p1:  [number, number]
+  cp1: [number, number]
+  cp2: [number, number]
+  p2:  [number, number]
+  /** Number of samples in the impulse response. Higher = longer tail
+   *  + more CPU. 256 ≈ 5.8ms @ 44.1kHz; 1024 ≈ 23ms. Capped at 1024
+   *  in the editor — longer IRs go through dedicated reverb. */
+  taps: number
+  /** Exponential decay rate applied to the curve so the kernel naturally
+   *  fades. 0 = no decay (raw curve). Larger = faster fade. */
+  decay: number
+  /** Output gain on the convolver branch. 0 disables; 1 = full kernel.
+   *  For events this sums with a parallel dry branch (so 0 = clean
+   *  signal, 1 = fully convolved). For loops the kernel is serial-
+   *  only — wet scales the kernel buffer values directly, which acts
+   *  as a dry/wet mix when the curve has an impulse near t=0. */
+  wet: number
 }
 export interface Registry {
   loops: LoopDef[]
@@ -209,6 +249,56 @@ interface LoopRuntime {
 // receives a deterministic chain (highpass → bandpass → lowpass = "trim
 // bottom, focus middle, trim top" in that order).
 const FILTER_NAMES = ['highpass', 'bandpass', 'lowpass'] as const
+/**
+ * Sample a cubic Bézier at t (0..1). Returns [x, y]. The kernel uses
+ * Bernstein form so all four control points contribute smoothly:
+ *   B(t) = (1-t)³·p1 + 3(1-t)²·t·cp1 + 3(1-t)·t²·cp2 + t³·p2
+ */
+function sampleCubicBezier(
+  p1: [number, number], cp1: [number, number],
+  cp2: [number, number], p2: [number, number],
+  t: number,
+): [number, number] {
+  const u = 1 - t
+  const u2 = u * u, u3 = u2 * u
+  const t2 = t * t, t3 = t2 * t
+  const x = u3 * p1[0] + 3 * u2 * t * cp1[0] + 3 * u * t2 * cp2[0] + t3 * p2[0]
+  const y = u3 * p1[1] + 3 * u2 * t * cp1[1] + 3 * u * t2 * cp2[1] + t3 * p2[1]
+  return [x, y]
+}
+
+/**
+ * Build a single-channel AudioBuffer from a KernelSpec (#65). Samples
+ * the curve at `taps` evenly-spaced t values, applies exp(-decay·t),
+ * scales by `wet`, normalises so peak = wet (so different decay rates
+ * produce comparable loudness). Curve y values can exceed [0..1] when
+ * control handles drive the spline outside the visible canvas — that's
+ * fine, sampleCubicBezier returns whatever the polynomial yields.
+ */
+function buildKernelBuffer(ctx: AudioContext, spec: KernelSpec): AudioBuffer {
+  const taps = Math.max(2, Math.min(1024, Math.floor(spec.taps)))
+  const buf = ctx.createBuffer(1, taps, ctx.sampleRate)
+  const data = buf.getChannelData(0)
+  // First pass: raw sampled curve × decay envelope.
+  let peak = 0
+  for (let i = 0; i < taps; i++) {
+    const t = i / (taps - 1)
+    const [, y] = sampleCubicBezier(spec.p1, spec.cp1, spec.cp2, spec.p2, t)
+    const env = spec.decay > 0 ? Math.exp(-spec.decay * t) : 1
+    const v = y * env
+    data[i] = v
+    const a = Math.abs(v)
+    if (a > peak) peak = a
+  }
+  // Normalise so the louder shape doesn't blow out vs. a quieter one.
+  // Then scale by wet — caller's "kernel intensity" knob.
+  if (peak > 1e-6) {
+    const scale = spec.wet / peak
+    for (let i = 0; i < taps; i++) data[i] *= scale
+  }
+  return buf
+}
+
 function buildFiltersForParams(ctx: AudioContext, params: Record<string, ParamSpec> | undefined): { nodes: BiquadFilterNode[]; map: Record<string, BiquadFilterNode> } {
   const map: Record<string, BiquadFilterNode> = {}
   const nodes: BiquadFilterNode[] = []
@@ -514,6 +604,33 @@ class AudioBus {
     return this.loops.get(key)?.def
   }
 
+  /** Set the kernel filter (#65) on a loop. Mutates audioLive (commit
+   *  source) AND triggers a reattach via registerLoop so the convolver
+   *  joins the filter chain. Brief audio glitch on swap is acceptable
+   *  for an authoring tool — perfect-smooth update would require
+   *  bypassing THREE.Audio's setFilters routing. Pass `undefined` to
+   *  remove the kernel. */
+  setLoopKernel(key: string, kernel: KernelSpec | undefined) {
+    const live = audioLive.loops.find(l => l.key === key)
+    if (live) {
+      if (kernel) live.kernel = kernel
+      else delete live.kernel
+      // Re-attach so the new convolver lands in setFilters.
+      this.registerLoop(live)
+    }
+  }
+
+  /** Set the kernel filter on an event. No re-attach needed — play()
+   *  reads def.kernel each call, so the next trigger uses the new
+   *  spec. */
+  setEventKernel(key: string, kernel: KernelSpec | undefined) {
+    const live = audioLive.events.find(e => e.key === key)
+    if (live) {
+      if (kernel) live.kernel = kernel
+      else delete live.kernel
+    }
+  }
+
   setWindStrengthSource(fn: () => number) {
     this.windStrengthGetter = fn
   }
@@ -674,10 +791,35 @@ class AudioBus {
         rate *= 1 - j + Math.random() * (2 * j)
       }
       src.playbackRate.value = rate
+      // Volume gain (event override × def). dst is what `src` actually
+      // connects to — either the volMul gain or sfxGain directly.
       const dst: AudioNode = volMul !== 1
         ? (() => { const g = ctx.createGain(); g.gain.value = volMul; g.connect(this.sfxGain!); return g })()
         : this.sfxGain
-      src.connect(dst)
+      // Kernel filter (#65) — convolve the source through a user-drawn
+      // impulse response. Per-play graph for events:
+      //
+      //   BufferSource → split:
+      //                    dry GainNode (gain = 1 - wet) ─→ dst
+      //                    ConvolverNode → wet GainNode (gain = 1) ─→ dst
+      //
+      // wet=0 → pure dry (convolver branch contributes nothing). wet=1
+      // → fully convolved + zero dry. The convolver's output gain is
+      // baked into the kernel buffer (peak normalised to wet), so the
+      // wet branch's GainNode stays at 1 and the dry branch's gain
+      // moves with (1 - wet). Net mix is constant-ish at unity.
+      if (def.kernel && def.kernel.wet > 0) {
+        const conv = ctx.createConvolver()
+        conv.buffer = buildKernelBuffer(ctx, def.kernel)
+        const dry = ctx.createGain()
+        dry.gain.value = Math.max(0, 1 - def.kernel.wet)
+        const wet = ctx.createGain()
+        wet.gain.value = 1
+        src.connect(dry); dry.connect(dst)
+        src.connect(conv); conv.connect(wet); wet.connect(dst)
+      } else {
+        src.connect(dst)
+      }
       // Track + auto-remove. 'ended' fires on natural finish AND on
       // explicit .stop() — same handler covers both paths.
       const list = this.activeEventSources.get(key) ?? []
@@ -1054,7 +1196,21 @@ class AudioBus {
         if (lr.def.rolloff != null) positional.setRolloffFactor(lr.def.rolloff)
         positional.setDistanceModel('linear'); if (lr.def.rolloff == null) positional.setRolloffFactor(1)
         const filters = buildFiltersForParams(ctx, lr.def.params)
-        if (filters.nodes.length) positional.setFilters(filters.nodes)
+        // Kernel convolver (#65) appends to the filter chain for loops.
+        // Serial-only — wet/dry split would require bypassing
+        // THREE.Audio's internal routing; not worth the complexity.
+        // Wet factor scales kernel buffer values (peak = wet), so a
+        // curve carrying an impulse near t=0 + wet=0.4 acts roughly
+        // like 60% dry / 40% reverb-tail.
+        const chain: AudioNode[] = [...filters.nodes]
+        if (lr.def.kernel && lr.def.kernel.wet > 0) {
+          const conv = ctx.createConvolver()
+          conv.buffer = buildKernelBuffer(ctx, lr.def.kernel)
+          chain.push(conv)
+        }
+        // THREE.Audio.setFilters is typed for BiquadFilterNode[] but
+        // accepts any AudioNode at runtime — the cast is safe.
+        if (chain.length) positional.setFilters(chain as BiquadFilterNode[])
         lr.filters = filters.map
         positional.setVolume(0)
         target.add(positional)
@@ -1070,7 +1226,13 @@ class AudioBus {
       a.setBuffer(buf)
       a.setLoop(true)
       const filters = buildFiltersForParams(ctx, lr.def.params)
-      if (filters.nodes.length) a.setFilters(filters.nodes)
+      const chain: AudioNode[] = [...filters.nodes]
+      if (lr.def.kernel && lr.def.kernel.wet > 0) {
+        const conv = ctx.createConvolver()
+        conv.buffer = buildKernelBuffer(ctx, lr.def.kernel)
+        chain.push(conv)
+      }
+      if (chain.length) a.setFilters(chain as BiquadFilterNode[])
       lr.filters = filters.map
       a.setVolume(0)
       const ovr = this.loopOverrides.get(lr.def.key)


### PR DESCRIPTION
## Summary

Per-entry convolution kernel — user draws a cubic Bézier in a 260×110 canvas; the curve becomes the impulse response of a `ConvolverNode` applied to that loop or event.

Closes #65. Builds on top of PR #64.

## Mechanism

- `KernelSpec`: `{ p1, cp1, cp2, p2, taps, decay, wet }` — 4 control points in normalised [0..1]², plus length / decay / mix.
- Bus samples the cubic at `taps` evenly-spaced t values, multiplies by `exp(-decay × t)`, normalises peak to `wet`, packs into a single-channel `AudioBuffer`.
- Events: per-play graph splits into parallel dry + wet branches (dry gain = 1 − wet, convolver output already peak-scaled). Net mix stays unity.
- Loops: convolver appended to `setFilters` chain (serial-only; wet/dry would require bypassing THREE.Audio routing). Wet factor scales kernel buffer values, acting as dry/wet only when curve carries an impulse near t=0.

## Editor

- New "Kernel filter" section in Inspector for both loops and events.
- 4 draggable points: 2 anchors (clamped to canvas) + 2 control handles (free).
- Renders: control polygon dashed, Bézier curve in `#4a8eef`, decay envelope overlay in dimmed red, dots for anchors/handles.
- Drag any point → live AudioBuffer rebuild; events hear the change on next trigger, loops re-attach (brief glitch).
- Sliders: taps (16–1024), decay (0–20), wet (0–1).
- + Add Kernel / Remove Kernel buttons.
- `buildSparseAudioJson` emits `kernel` field for both loops and events when present, so Commit persists the IR shape into per-level `audio.json`.

## Test plan

- [ ] Select `theme_music` → + Add Kernel → sliders appear, default attack-decay shape renders
- [ ] Drag the right blue handle far above the canvas → curve flips concave-down, kernel changes audibly
- [ ] Move taps slider 16 → 1024 → audible IR length change
- [ ] Decay 0 → 20 → tail shortens; the red overlay tracks the slider
- [ ] Wet 0 → 1 on an event (e.g. `tile_snap`) → cycles between clean click and convolved click
- [ ] Remove Kernel → entry returns to dry signal
- [ ] Commit Audio → reload page → kernel persists; canvas re-renders with the same curve

## Constraints (intentional)

- Mono kernel — no stereo widening
- Single cubic segment — not multi-segment splines
- Capped at 1024 taps (~23 ms @ 44.1kHz) — long IRs go through Round 3 (reverb send + room presets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)