### PR TITLE
🔄 Audio editor: per-sound "Reset to default"

### DIFF
--- a/src/AudioEditorRoute.tsx
+++ b/src/AudioEditorRoute.tsx
@@ -153,6 +153,14 @@ function AudioWorkspace() {
   }, [])
   void tick
 
+  // Dev-only handle to the audio bus — mirrors window.__planet. Lets
+  // Playwright read/seed bus state without DOM scraping. Stripped in prod.
+  useEffect(() => {
+    if (import.meta.env.DEV) {
+      ;(window as unknown as { __audioBus?: typeof audioBus }).__audioBus = audioBus
+    }
+  }, [])
+
   const entries: Entry[] = useMemo(() => [
     ...audioLive.loops.map((def): Entry => ({ kind: 'loop', def })),
     ...audioLive.events.map((def): Entry => ({ kind: 'event', def })),
@@ -174,6 +182,18 @@ function AudioWorkspace() {
   }, [lastKey, lastN])
 
   const selected = entries.find(e => e.def.key === selectedKey) ?? entries[0] ?? null
+
+  // Bumped on reset to remount the Inspector so every slider / ADSR / waveform
+  // re-reads the now-default values instead of its stale internal state.
+  const [resetNonce, setResetNonce] = useState(0)
+  const onResetEntry = useCallback((entry: Entry) => {
+    if (!audioBus.resetEntryToDefault(entry.def.key)) return
+    // Drop from the commit-tracking sets so a following Commit omits this
+    // entry from audio.json — reset must escape the persisted override too.
+    if (entry.kind === 'loop') editedParamKeys.delete(entry.def.key)
+    else editedEventKeys.delete(entry.def.key)
+    setResetNonce(n => n + 1)
+  }, [])
 
   const slug = audioBootSlug
   const [committing, setCommitting] = useState<'idle' | 'committing' | 'ok' | 'err'>('idle')
@@ -249,7 +269,11 @@ function AudioWorkspace() {
           onSelect={setSelectedKey}
           lockSelection={lockSelection}
         />
-        <Inspector entry={selected} />
+        <Inspector
+          entry={selected}
+          onReset={onResetEntry}
+          key={`${selected?.def.key ?? 'none'}:${resetNonce}`}
+        />
       </div>
     </>
   )
@@ -387,7 +411,7 @@ function EventList({
 
 // ── Inspector ──────────────────────────────────────────────────────────
 
-function Inspector({ entry }: { entry: Entry | null }) {
+function Inspector({ entry, onReset }: { entry: Entry | null; onReset: (entry: Entry) => void }) {
   if (!entry) {
     return (
       <div style={{ flex: '1 1 50%', padding: 16, opacity: 0.5, fontStyle: 'italic' }}>
@@ -395,9 +419,27 @@ function Inspector({ entry }: { entry: Entry | null }) {
       </div>
     )
   }
+  const canReset = audioBus.hasRegistryDefault(entry.def.key)
   return (
     <div style={{ flex: '1 1 50%', minHeight: 200, padding: 12, overflowY: 'auto' }}>
-      <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 8 }}>{entry.def.key}</div>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, marginBottom: 8 }}>
+        <span style={{ fontSize: 13, fontWeight: 600 }}>{entry.def.key}</span>
+        <button
+          disabled={!canReset}
+          title={canReset
+            ? 'Restore this sound to its registry.json default — discards live edits and overrides'
+            : 'No compiled-in default for this entry (e.g. a glb-imported sound)'}
+          onClick={() => {
+            if (!canReset) return
+            if (window.confirm(`Reset "${entry.def.key}" to its default?\n\nThis discards live edits and overrides for this sound.`)) {
+              onReset(entry)
+            }
+          }}
+          style={{ ...btn, padding: '4px 10px', fontSize: 11, whiteSpace: 'nowrap', opacity: canReset ? 1 : 0.4, cursor: canReset ? 'pointer' : 'not-allowed' }}
+        >
+          Reset to default
+        </button>
+      </div>
       <div style={{ fontSize: 11, opacity: 0.7, fontFamily: 'ui-monospace, monospace', wordBreak: 'break-all', marginBottom: 8 }}>
         {entry.def.src}
       </div>

--- a/src/world/audio/audioLive.ts
+++ b/src/world/audio/audioLive.ts
@@ -98,6 +98,15 @@ if (bootLevelSlug) {
  *  and the bus picks up the new values on its next tick. */
 export const audioLive: Registry = _live
 
+/** Pristine compiled-in defaults (`registry.json`), never mutated. The
+ *  editor's "Reset to default" (issue #75) restores an entry from here.
+ *  Kept as a SEPARATE clone from `audioLive` — which boot-merges per-level
+ *  overrides and then absorbs live edits in place — so the factory baseline
+ *  stays reachable no matter how much the live registry drifts. Per-level
+ *  audio.json is deliberately NOT merged in: "default" means the global
+ *  compiled-in value, so reset escapes a level override too. */
+export const audioDefaults: Registry = deepClone(registryJson) as unknown as Registry
+
 /** Mark this audio.json as live-loaded for THIS slug, so the editor's
  *  Commit endpoint knows where to write. Mirrors `bootLevelSlug`. */
 export const audioBootSlug: string | null = bootLevelSlug

--- a/src/world/audio/bus.ts
+++ b/src/world/audio/bus.ts
@@ -128,7 +128,7 @@ export type Category = 'master' | 'ambient' | 'sfx'
 // type). Type-only re-import means no runtime cycle. The runtime value
 // (`audioLive`) is read on demand below, so the import resolves after both
 // modules' bodies have finished.
-import { audioLive } from './audioLive'
+import { audioLive, audioDefaults } from './audioLive'
 export const REGISTRY: Registry = audioLive
 
 type Modulator = () => number
@@ -588,6 +588,47 @@ class AudioBus {
   }
   getLoopOverride(key: string) { return this.loopOverrides.get(key) }
   getEventOverride(key: string) { return this.eventOverrides.get(key) }
+
+  /** True if `key` has a compiled-in registry.json default — i.e. reset is
+   *  meaningful. False for glb-imported KHR_audio_emitter runtime loops or
+   *  level-only entries, which have no factory baseline to restore. The
+   *  editor uses this to disable its "Reset to default" button. */
+  hasRegistryDefault(key: string): boolean {
+    return audioDefaults.loops.some(l => l.key === key)
+        || audioDefaults.events.some(e => e.key === key)
+  }
+
+  /** Reset a loop/event to its compiled-in registry.json default — issue #75.
+   *  Restores EVERY layer that feeds the effective sound: the audioLive entry
+   *  (commit source), the runtime def, and the ephemeral override map. The
+   *  editor additionally drops the key from its commit-tracking sets so a
+   *  following Commit omits the entry from audio.json. Returns false (no-op)
+   *  if `key` has no registry default — see hasRegistryDefault. */
+  resetEntryToDefault(key: string): boolean {
+    const defLoop = audioDefaults.loops.find(l => l.key === key)
+    if (defLoop) {
+      const restored = JSON.parse(JSON.stringify(defLoop)) as LoopDef
+      const idx = audioLive.loops.findIndex(l => l.key === key)
+      if (idx >= 0) audioLive.loops[idx] = restored
+      this.loopOverrides.delete(key)
+      // registerLoop is idempotent: tears down the existing node and re-attaches
+      // with the default src/params/radius. Picks up the default buffer if the
+      // sample was swapped.
+      this.registerLoop(restored)
+      return true
+    }
+    const defEvent = audioDefaults.events.find(e => e.key === key)
+    if (defEvent) {
+      // Events read their def from REGISTRY (=== audioLive) on every play(),
+      // so restoring the audioLive entry + clearing the override is sufficient;
+      // there's no separate runtime node to rebuild.
+      const idx = audioLive.events.findIndex(e => e.key === key)
+      if (idx >= 0) audioLive.events[idx] = JSON.parse(JSON.stringify(defEvent)) as EventDef
+      this.eventOverrides.delete(key)
+      return true
+    }
+    return false
+  }
   // For the visualiser — return the gain we last computed for this loop.
   getLastLoopGain(key: string): number {
     const lr = this.loops.get(key)

--- a/tests/audio-reset-commit-drop.mjs
+++ b/tests/audio-reset-commit-drop.mjs
@@ -1,0 +1,68 @@
+// Observe issue #75 acceptance: reset → commit DROPS the entry from audio.json.
+//
+// Seed an override on a loop, Commit (entry appears in audio.json), Reset,
+// Commit again (entry gone). Proves reset escapes the persisted override —
+// not just the live state. Cleans up the created audio.json afterward.
+import { chromium } from 'playwright'
+import { readFileSync, existsSync, rmSync } from 'node:fs'
+
+const BASE = 'http://localhost:5175'
+const URL = `${BASE}/edit/levels/lvl_1/audio`
+const KEY = 'theme_music'
+const AUDIO_JSON = 'public/levels/lvl_1/audio.json'
+
+const results = []
+const ok = (label, cond, detail = '') => results.push({ label, pass: !!cond, detail })
+const readJson = () => existsSync(AUDIO_JSON) ? JSON.parse(readFileSync(AUDIO_JSON, 'utf8')) : null
+const hasKey = (j) => !!j && [...(j.loops ?? []), ...(j.events ?? [])].some(e => e.key === KEY)
+
+// Start clean.
+if (existsSync(AUDIO_JSON)) rmSync(AUDIO_JSON)
+
+const browser = await chromium.launch({ headless: true })
+const page = await browser.newPage()
+await page.goto(URL, { waitUntil: 'domcontentloaded' })
+await page.waitForFunction(() => !!(window).__audioBus, null, { timeout: 15000 })
+await page.getByRole('button', { name: 'Reset to default' }).waitFor({ state: 'visible', timeout: 10000 })
+
+// Helpers: dispatch the REAL React onClick programmatically. A synthetic
+// mouse click is flaky once the WebGL scene is hammering the compositor
+// (test audio-reset-default.mjs already proves a real click works); here we
+// only need the handler to run. Stub confirm() so Reset proceeds.
+await page.evaluate(() => { window.confirm = () => true })
+const clickByText = (txt) => page.evaluate((t) => {
+  const el = [...document.querySelectorAll('button')].find(b => b.textContent?.trim() === t)
+  if (!el) throw new Error(`button not found: ${t}`)
+  el.click()
+}, txt)
+
+// 1. Seed an override and Commit → entry should land in audio.json.
+await page.evaluate((key) => (window).__audioBus.setLoopOverride(key, { vol: 0.5, mute: true }), KEY)
+await clickByText('Commit Audio')
+await page.waitForTimeout(700)
+const afterEdit = readJson()
+ok('after edit+commit: audio.json contains theme_music', hasKey(afterEdit),
+   `loops=${JSON.stringify(afterEdit?.loops?.map(l => l.key))}`)
+
+// 2. Reset, then Commit again → entry should be gone.
+await clickByText('Reset to default')
+await page.waitForTimeout(400)
+await clickByText('Commit Audio')
+await page.waitForTimeout(700)
+const afterReset = readJson()
+ok('after reset+commit: theme_music dropped from audio.json', !hasKey(afterReset),
+   `loops=${JSON.stringify(afterReset?.loops?.map(l => l.key))}`)
+
+await browser.close()
+
+// Cleanup — leave the tree as we found it.
+if (existsSync(AUDIO_JSON)) rmSync(AUDIO_JSON)
+
+console.log('\n=== reset → commit-drop observation ===\n')
+let allPass = true
+for (const r of results) {
+  console.log(`  ${r.pass ? '✓' : '✗'} ${r.label}${!r.pass && r.detail ? '  (' + r.detail + ')' : ''}`)
+  if (!r.pass) allPass = false
+}
+console.log(`\n${allPass ? 'ALL PASS' : 'FAILURES PRESENT'}\n`)
+process.exit(allPass ? 0 : 1)

--- a/tests/audio-reset-default.mjs
+++ b/tests/audio-reset-default.mjs
@@ -1,0 +1,75 @@
+// Observe issue #75: per-sound "Reset to default" in the audio editor.
+//
+// Seeds a param edit + ephemeral overrides on a loop via the dev bus hook,
+// then drives the REAL Reset button in the UI and asserts every layer is
+// restored to the registry.json default: runtime def params, override map.
+import { chromium } from 'playwright'
+
+const URL = 'http://localhost:5175/edit/levels/lvl_1/audio'
+const KEY = 'theme_music'          // first loop; auto-selected on load
+const DEFAULT_BASE = 0.22          // registry.json theme_music.params.vol.base
+
+const browser = await chromium.launch({ headless: true })
+const page = await browser.newPage()
+page.on('console', m => { if (m.type() === 'error') console.log('  [page error]', m.text()) })
+page.on('dialog', d => d.accept())  // accept the reset confirm()
+
+const results = []
+const ok = (label, cond, detail = '') => { results.push({ label, pass: !!cond, detail }); }
+
+await page.goto(URL, { waitUntil: 'domcontentloaded' })
+
+// Wait for the dev bus hook to attach.
+await page.waitForFunction(() => !!(window).__audioBus, null, { timeout: 15000 })
+
+// 1. hasRegistryDefault semantics — gates the button's enabled state.
+const pre = await page.evaluate((key) => {
+  const b = (window).__audioBus
+  return {
+    hasDefault: b.hasRegistryDefault(key),
+    hasDefaultBogus: b.hasRegistryDefault('___nope___'),
+  }
+}, KEY)
+ok('hasRegistryDefault(theme_music) = true', pre.hasDefault === true)
+ok('hasRegistryDefault(bogus) = false', pre.hasDefaultBogus === false)
+
+// 2. Seed a param edit + ephemeral overrides (what the UI would produce).
+//    Force-register the loop first so the runtime def edit is observable
+//    (in the editor a loop may not be in this.loops until first play).
+const seeded = await page.evaluate((key) => {
+  const b = (window).__audioBus
+  const def = b.getLoopRuntimeDef(key) ?? { key, anchor: 'world', src: 'audio/theme.ogg' }
+  b.registerLoop({ ...def, params: { ...(def.params ?? {}), vol: { base: 0.99, modulator: 'themeWalkDuck' } } })
+  b.setLoopOverride(key, { vol: 0.42, mute: true })
+  return { base: b.getLoopRuntimeDef(key)?.params?.vol?.base, override: b.getLoopOverride(key) ?? null }
+}, KEY)
+ok('seed: runtime base now 0.99', seeded.base === 0.99, `got ${seeded.base}`)
+ok('seed: override present', seeded.override && seeded.override.vol === 0.42 && seeded.override.mute === true)
+
+// 3. theme_music is auto-selected on load, so the Inspector already shows it.
+//    Click the real Reset button (confirm() auto-accepted by the dialog handler).
+const resetBtn = page.getByRole('button', { name: 'Reset to default' })
+await resetBtn.waitFor({ state: 'visible', timeout: 10000 })
+const disabled = await resetBtn.isDisabled()
+ok('reset button enabled for entry with default', disabled === false)
+await resetBtn.click()
+
+// 4. Assert every layer restored.
+await page.waitForTimeout(400)
+const post = await page.evaluate((key) => {
+  const b = (window).__audioBus
+  return { base: b.getLoopRuntimeDef(key)?.params?.vol?.base, override: b.getLoopOverride(key) ?? null }
+}, KEY)
+ok('after reset: base back to 0.22', post.base === DEFAULT_BASE, `got ${post.base}`)
+ok('after reset: override cleared', post.override === null, `got ${JSON.stringify(post.override)}`)
+
+await browser.close()
+
+console.log('\n=== reset-to-default observation ===\n')
+let allPass = true
+for (const r of results) {
+  console.log(`  ${r.pass ? '✓' : '✗'} ${r.label}${r.detail && !r.pass ? '  (' + r.detail + ')' : ''}`)
+  if (!r.pass) allPass = false
+}
+console.log(`\n${allPass ? 'ALL PASS' : 'FAILURES PRESENT'}\n`)
+process.exit(allPass ? 0 : 1)


### PR DESCRIPTION
Closes #75.

## Summary

Adds a **"Reset to default"** button to the audio editor's Inspector, scoped to the selected sound. It restores the entry to its `registry.json` default and clears every layer that contributes to the effective sound — so you can always get a sound back to its known-good baseline after editing.

Restored layers:
- **`audioLive` entry** (commit source) — from a new pristine `audioDefaults` clone of `registry.json`. `audioLive` was already a deep clone, so the factory baseline survives untouched even after live edits.
- **runtime def** — loops re-register via the idempotent `registerLoop`; events read from `audioLive` at play time (no rebuild needed).
- **ephemeral override map** (`loopOverrides` / `eventOverrides`).
- **editor commit-tracking sets** (`editedParamKeys` / `editedEventKeys`) — so a following Commit *drops* the entry from the level's `audio.json`.

`bus.resetEntryToDefault(key)` does the restore; `hasRegistryDefault(key)` disables the button for entries with no compiled-in default (e.g. glb-imported KHR_audio_emitter loops). The Inspector remounts on reset (keyed on `resetNonce`) so every slider / ADSR / waveform re-reads the defaults. A dev-only `window.__audioBus` hook (mirrors `window.__planet`, stripped in prod) was added for observability.

## Test plan

Verified (observed, not inferred) via two Playwright scripts:

- [x] `tests/audio-reset-default.mjs` — seed a param edit (`vol.base` 0.22→0.99) + overrides, click the **real** Reset button → runtime base restored to 0.22, override map cleared, button correctly enabled (and `hasRegistryDefault('bogus')` false). **ALL PASS.**
- [x] `tests/audio-reset-commit-drop.mjs` — edit + Commit → `theme_music` appears in `audio.json`; Reset + Commit → entry dropped. **ALL PASS.** (cleans up after itself)
- [x] `tsc --noEmit` clean.
- [x] No new eslint errors (pre-existing ones in the file are untouched).

## Notes

- Surfaced an incidental pre-existing behavior: in the editor a loop may not be in the bus's runtime `this.loops` until first play, while a boot-time override sits in the override map. Reset's `registerLoop` registers it cleanly. Not a regression.