### PR TITLE
🎯 Audio editor: auto-highlight axis_rotation on slice rotate

### DIFF
--- a/src/world/audio/lastTriggered.ts
+++ b/src/world/audio/lastTriggered.ts
@@ -1,15 +1,20 @@
 import { create } from 'zustand'
 
 /**
- * Records the most recent one-shot event firing — read by the audio
- * editor's event list (`/edit/levels/<slug>/audio`, issue #51) to flash
- * + auto-scroll the row that just fired. Lets the user rotate a tile and
- * watch `tile_rotate` (when wired) light up on the left, then drag a
- * pitchJitter slider on the right to hear the change next rotate.
+ * Records the most recent triggered sound — read by the audio editor's
+ * list (`/edit/levels/<slug>/audio`, issue #51) to flash + auto-scroll
+ * the row that just fired. Lets the user rotate a tile and watch the
+ * `axis_rotation` row light up on the left, then drag a slider on the
+ * right to hear the change next rotation.
  *
- * Loops are intentionally NOT tracked here — they fire continuously, so
- * "last triggered" doesn't carry information for them. The editor reads
- * live gain via audioBus.getDebugSnapshot() for loops instead.
+ * What publishes here:
+ *   - One-shot events via `audioBus.play(key)` — every play emits.
+ *   - Gesture-bound loops via their subscription handler (e.g.
+ *     `subscriptions.ts` publishes `axis_rotation` on the rising edge of
+ *     slice-rotation activation, ONCE per gesture — #77). Continuous-tick
+ *     loops (ambient_world, birds_flock, …) don't publish; "last
+ *     triggered" carries no information for them, and the editor reads
+ *     their live gain via audioBus instead.
  *
  * `n` is a monotonic counter (NOT just a timestamp) — two triggers
  * within the same animation frame still produce distinct values. The

--- a/src/world/audio/subscriptions.ts
+++ b/src/world/audio/subscriptions.ts
@@ -9,6 +9,7 @@
 
 import { usePlanet } from '../store'
 import { audioBus } from './bus'
+import { useLastTriggered } from './lastTriggered'
 
 let installed = false
 
@@ -16,10 +17,25 @@ export function installAudioSubscriptions() {
   if (installed) return
   installed = true
 
+  // Rising-edge memory so we publish ONCE per rotation gesture, not on
+  // every drag frame. zustand's listener form gives only `state`, no
+  // prev — we compare against this local for the transition.
+  let prevSliceActive = 0
+
   // Track drag + anim presence; bus tick smooths attack/release so the
   // rumble fades naturally rather than snapping at boundary frames.
   usePlanet.subscribe(state => {
     const active = (state.drag != null || state.anim != null) ? 1 : 0
     audioBus.setSliceRotationActive(active as 0 | 1)
+    if (active === 1 && prevSliceActive === 0) {
+      // Discoverability bridge (#77): the modulator-driven axis_rotation
+      // loop has no audioBus.play() call to surface it in the audio editor.
+      // Publishing on the rising edge lets the editor's auto-select +
+      // flash-row UX point at the rumble loop the moment a rotation
+      // starts — same path as one-shot events. Once per gesture, not
+      // continuously, so the flash doesn't strobe across drag frames.
+      useLastTriggered.getState().publish('axis_rotation')
+    }
+    prevSliceActive = active
   })
 }

--- a/tests/audio-rotate-autoselect.mjs
+++ b/tests/audio-rotate-autoselect.mjs
@@ -1,0 +1,58 @@
+// Observe #77: starting a slice rotation auto-selects the axis_rotation
+// row in the audio editor.
+//
+// Drives the existing window.__planet store hook to flip the rotation-
+// active condition (state.drag truthy) → the audio subscription publishes
+// 'axis_rotation' to useLastTriggered → the editor's auto-select effect
+// switches the Inspector to that row.
+//
+// Kept minimal — multi-gesture / rising-edge behavior was verified by code
+// review (a single boolean `prevSliceActive` flag); the costly bit to
+// observe is the end-to-end wiring of one rotation → editor highlight.
+import { chromium } from 'playwright'
+
+const URL = 'http://localhost:5175/edit/levels/lvl_1/audio'
+
+const browser = await chromium.launch({ headless: true })
+const page = await browser.newPage()
+await page.goto(URL, { waitUntil: 'domcontentloaded' })
+await page.waitForFunction(() => !!(window).__planet, null, { timeout: 15000 })
+await page.waitForTimeout(800)
+
+const inspectorKey = () => page.evaluate(() => {
+  const btn = [...document.querySelectorAll('button')].find(b => b.textContent?.trim() === 'Replace sample…')
+  if (!btn) return null
+  let n = btn.parentElement
+  while (n && n.parentElement) {
+    if (getComputedStyle(n).overflowY === 'auto') break
+    n = n.parentElement
+  }
+  return n?.children?.[0]?.textContent?.trim() ?? null
+})
+
+const initial = await inspectorKey()
+const beforeOk = initial && initial !== 'axis_rotation'
+
+// One write to flip drag truthy. Setting state directly (no .getState().setDrag)
+// because we want the subscription listener to fire — and zustand fires it on
+// any setState. The shape here only needs to be NOT null for the subscription's
+// `state.drag != null` check; scene code may read more fields but the Inspector
+// only depends on selectedKey which we observe via DOM.
+await page.evaluate(() => {
+  (window).__planet.setState({ drag: { axis: 'x', start: 0, slice: 0 } })
+})
+await page.waitForTimeout(500)
+const after = await inspectorKey()
+
+// Clean up — return drag to null so the page doesn't sit in a half-rotated state.
+await page.evaluate(() => (window).__planet.setState({ drag: null }))
+await browser.close()
+
+const ok1 = !!beforeOk
+const ok2 = after === 'axis_rotation'
+console.log('\n=== rotation auto-highlight observation ===\n')
+console.log(`  ${ok1 ? '✓' : '✗'} on load: Inspector shows a sound (not axis_rotation)  (got ${initial})`)
+console.log(`  ${ok2 ? '✓' : '✗'} after rotation start: Inspector switched to axis_rotation  (got ${after})`)
+const allPass = ok1 && ok2
+console.log(`\n${allPass ? 'ALL PASS' : 'FAILURES PRESENT'}\n`)
+process.exit(allPass ? 0 : 1)


### PR DESCRIPTION
Closes #77.

## Problem

The slice-rotation rumble is a modulator-driven loop (`axis_rotation`, gated by `sliceRotationActive` in `subscriptions.ts`), not a one-shot event. The editor's auto-select-on-trigger only fires for events routed through `audioBus.play()`, so rotating a slice never pointed the editor at the responsible row — the rotation sound felt invisible/uneditable even though the row is right there.

`lastTriggered.ts:8` even documented this gap: *"watch `tile_rotate` light up (when wired)"*. Never wired.

## Fix

In `subscriptions.ts`, detect the **0→1 rising edge** of `sliceRotationActive` (module-scope `prevSliceActive` flag — zustand's listener form gives only `state`, no `prev`) and call `useLastTriggered.publish('axis_rotation')`. The editor's existing auto-select + flash-row effects pick it up automatically — same UX path as a one-shot event firing. **Once per gesture**, not continuously across drag frames. The existing Lock Selection toggle remains the opt-out.

`lastTriggered.ts` doc header updated: loops *are* tracked when driven by a discrete gesture (rising-edge only); continuous-tick loops still aren't.

## Test plan

- [x] `tests/audio-rotate-autoselect.mjs` — drives `window.__planet.setState({drag: …})`, asserts the Inspector switches to `axis_rotation`. **ALL PASS.**
- [x] `tsc --noEmit` clean.
- [x] The rising-edge "once per gesture" contract is a single boolean flag — verified by code review, not worth fighting scene reconciliation cost for in Playwright.

## Try it

Open `/edit/levels/lvl_1/audio`, then drag any sub-face. The Inspector should jump to `axis_rotation` the moment the drag starts.