### PR TITLE
🎛️ Audio editor Round 2: 3-band parametric EQ + frequency-response preview

### DIFF
--- a/src/AudioEditorRoute.tsx
+++ b/src/AudioEditorRoute.tsx
@@ -17,8 +17,15 @@ const editedParamKeys = new Set<string>()
 const editedEventKeys = new Set<string>()
 
 /** Filter-type params the editor knows how to add. Bus already wires
- *  BiquadFilters for these names (#54). */
-const FILTER_TYPES = ['lowpass', 'highpass', 'bandpass'] as const
+ *  BiquadFilters for these names (#54 + #81 for the EQ trio). Order
+ *  here mirrors the bus's mastering chain order so the Add buttons read
+ *  left-to-right the way the chain processes. */
+const FILTER_TYPES = ['highpass', 'lowshelf', 'bandpass', 'peaking', 'highshelf', 'lowpass'] as const
+/** Gainy filter types — render a gain (dB) slider in the editor. Shelves
+ *  + peaking ride on BiquadFilterNode.gain (dB); cuts/bandpass don't.
+ *  Q is also hidden for shelves (the WebAudio spec ignores Q for them). */
+const GAIN_FILTER_TYPES = ['lowshelf', 'peaking', 'highshelf'] as const
+const SHELF_TYPES = ['lowshelf', 'highshelf'] as const
 
 /** All knobs the editor can manage on a loop. `vol` and `rate` are
  *  always present once a user touches them; filters are opt-in via the
@@ -627,7 +634,144 @@ function WaveformCanvas({ src }: { src: string }) {
   )
 }
 
-// ── ParamsEditor — modulator + min/max + filters (#53, #54) ────────────
+// ── FrequencyResponseCanvas — combined EQ/cut chain magnitude (#81) ────
+
+/**
+ * Render the combined frequency response of all active filter params on
+ * a loop — re-uses BiquadFilterNode.getFrequencyResponse against a
+ * throwaway OfflineAudioContext, sums per-filter magnitudes in dB, plots
+ * log-x (20 Hz → 20 kHz), linear-y (±24 dB).
+ *
+ * Re-reads the runtime def on every render. ParamsEditor force-renders
+ * on every param edit, so dragging a slider updates the curve immediately
+ * — same path as the audible chain (bus reads the same spec on its next
+ * tick), so visual + audible stay in lockstep without a separate sync.
+ */
+const RESPONSE_NUM_POINTS = 256
+const RESPONSE_DB_MIN = -24
+const RESPONSE_DB_MAX = 24
+/** 256 log-spaced freqs from 20 Hz to 20 kHz. Computed once. */
+const RESPONSE_FREQS = (() => {
+  const a = new Float32Array(RESPONSE_NUM_POINTS)
+  for (let i = 0; i < RESPONSE_NUM_POINTS; i++) {
+    const t = i / (RESPONSE_NUM_POINTS - 1)
+    a[i] = 20 * Math.pow(1000, t)
+  }
+  return a
+})()
+
+/** Single shared OfflineAudioContext for getFrequencyResponse() calc.
+ *  Browsers cap AudioContexts per page (~6 in Chrome); creating one per
+ *  render would throw after a handful of heartbeat re-renders and crash
+ *  the panel. Lazily created, reused forever — the BiquadFilterNodes built
+ *  against it are throwaway and never connected to a destination. */
+let _responseCalcCtx: OfflineAudioContext | null | undefined
+function getResponseCalcCtx(): OfflineAudioContext | null {
+  if (_responseCalcCtx !== undefined) return _responseCalcCtx
+  const Ctx = window.OfflineAudioContext
+            ?? (window as unknown as { webkitOfflineAudioContext?: typeof OfflineAudioContext }).webkitOfflineAudioContext
+  _responseCalcCtx = Ctx ? new Ctx(1, 1, 44100) : null
+  return _responseCalcCtx
+}
+
+function FrequencyResponseCanvas({ loopKey }: { loopKey: string }) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const def = audioBus.getLoopRuntimeDef(loopKey)
+  const params = def?.params ?? {}
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const dpr = window.devicePixelRatio ?? 1
+    const w = canvas.clientWidth || 320
+    const h = canvas.clientHeight || 90
+    canvas.width = w * dpr
+    canvas.height = h * dpr
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.scale(dpr, dpr)
+    ctx.clearRect(0, 0, w, h)
+
+    // Build BiquadFilters mirroring the loop's active filter params, then
+    // sum magnitudes in dB. Browsers cap the number of AudioContexts per
+    // page (~6 in Chrome), so we must NOT create one per render/heartbeat —
+    // reuse a single shared OfflineAudioContext (responseCalcCtx). The
+    // nodes built here are never wired to a destination, just used as
+    // getFrequencyResponse() calculators.
+    const oc = getResponseCalcCtx()
+    if (!oc) return
+    const sumDb = new Float32Array(RESPONSE_NUM_POINTS)
+    const mag = new Float32Array(RESPONSE_NUM_POINTS)
+    const phase = new Float32Array(RESPONSE_NUM_POINTS)
+    const filterNames = ['highpass', 'lowshelf', 'bandpass', 'peaking', 'highshelf', 'lowpass'] as const
+    let activeCount = 0
+    for (const name of filterNames) {
+      const spec = params[name]
+      if (!spec) continue
+      activeCount++
+      const f = oc.createBiquadFilter()
+      f.type = name as BiquadFilterType
+      // base × modulator isn't accessible without a running tick — show
+      // the static base. Live modulation isn't graphable without picking a
+      // moment in time anyway, and the user reaches for this panel to
+      // shape the static EQ curve.
+      f.frequency.value = spec.base ?? 1000
+      if (spec.q != null) f.Q.value = spec.q
+      if (spec.gain != null) f.gain.value = spec.gain
+      f.getFrequencyResponse(RESPONSE_FREQS, mag, phase)
+      for (let i = 0; i < RESPONSE_NUM_POINTS; i++) {
+        sumDb[i] += 20 * Math.log10(Math.max(mag[i], 1e-6))
+      }
+    }
+
+    // Plot space helpers.
+    const yOf = (db: number) => h * (1 - (db - RESPONSE_DB_MIN) / (RESPONSE_DB_MAX - RESPONSE_DB_MIN))
+    const xOf = (i: number) => (i / (RESPONSE_NUM_POINTS - 1)) * w
+
+    // ±12 dB + 0 dB grid lines.
+    ctx.lineWidth = 1
+    for (const db of [-12, 12]) {
+      ctx.strokeStyle = '#141a23'
+      ctx.beginPath(); ctx.moveTo(0, yOf(db)); ctx.lineTo(w, yOf(db)); ctx.stroke()
+    }
+    ctx.strokeStyle = '#1e242e'
+    ctx.beginPath(); ctx.moveTo(0, yOf(0)); ctx.lineTo(w, yOf(0)); ctx.stroke()
+
+    // Magnitude curve. Skip rendering if no filters active — leaves the
+    // grid as a quiet hint that the canvas IS the EQ preview surface.
+    if (activeCount > 0) {
+      ctx.strokeStyle = '#7aa8ef'
+      ctx.lineWidth = 1.5
+      ctx.beginPath()
+      for (let i = 0; i < RESPONSE_NUM_POINTS; i++) {
+        const x = xOf(i)
+        const y = yOf(sumDb[i])
+        if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y)
+      }
+      ctx.stroke()
+    }
+    // params is a fresh ref whenever setLoopParamSpec mutates the entry —
+    // exactly when we want to repaint. Intentional dep.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params, loopKey])
+
+  return (
+    <div style={{ marginTop: 10 }}>
+      <div style={{ fontSize: 10, opacity: 0.55, textTransform: 'uppercase', letterSpacing: 1, marginBottom: 4 }}>
+        Frequency response
+      </div>
+      <canvas
+        ref={canvasRef}
+        style={{ width: '100%', height: 90, display: 'block', borderRadius: 3, background: '#0a0d12' }}
+      />
+      <div style={{ fontSize: 9, opacity: 0.4, marginTop: 2, display: 'flex', justifyContent: 'space-between', fontFamily: 'ui-monospace, monospace' }}>
+        <span>20 Hz</span><span>200</span><span>2 k</span><span>20 kHz</span>
+      </div>
+    </div>
+  )
+}
+
+// ── ParamsEditor — modulator + min/max + filters (#53, #54, #81) ───────
 
 /**
  * Edits the persistent param spec (`{ base, modulator, min, max, invert }`)
@@ -669,14 +813,19 @@ function ParamsEditor({ loopKey }: { loopKey: string }) {
   }
 
   const addParam = (name: ParamType) => {
-    // Sensible defaults per param type. Filters open at midband so the
-    // user can immediately drag toward the sound they want.
+    // Sensible defaults per param type. Cut filters open at midband; EQ
+    // bands (#81) start transparent (0 dB) at typical centre frequencies
+    // so adding one is audibly a no-op until the user reaches for the
+    // gain slider — matches the mental model "add the band, then shape".
     const defaults: Record<ParamType, ParamSpec> = {
-      vol:      { base: 1 },
-      rate:     { base: 1 },
-      lowpass:  { base: 4000 },
-      highpass: { base: 200 },
-      bandpass: { base: 1500 },
+      vol:       { base: 1 },
+      rate:      { base: 1 },
+      lowpass:   { base: 4000 },
+      highpass:  { base: 200 },
+      bandpass:  { base: 1500 },
+      lowshelf:  { base: 200,  gain: 0 },
+      peaking:   { base: 1000, gain: 0, q: 1.0 },
+      highshelf: { base: 5000, gain: 0 },
     }
     audioBus.setLoopParamSpec(loopKey, name, defaults[name])
     editedParamKeys.add(loopKey)
@@ -715,6 +864,7 @@ function ParamsEditor({ loopKey }: { loopKey: string }) {
           </button>
         ))}
       </div>
+      <FrequencyResponseCanvas loopKey={loopKey} />
     </div>
   )
 }
@@ -728,6 +878,10 @@ function ParamRow({
   onChange: (partial: Partial<ParamSpec>) => void
 }) {
   const isFilter = (FILTER_TYPES as readonly string[]).includes(name)
+  // Shelves + peaking carry a gain (dB) AudioParam; cuts/bandpass don't.
+  // Shelves additionally ignore Q per WebAudio spec — hide that slider.
+  const isGainFilter = (GAIN_FILTER_TYPES as readonly string[]).includes(name)
+  const isShelf = (SHELF_TYPES as readonly string[]).includes(name)
   // Filter cutoffs span 20Hz – 20kHz; vol is 0–2; rate is 0.25–4. Pick
   // the slider range that matches what the user expects.
   const range = isFilter ? { min: 20, max: 20000, step: 1 }
@@ -795,7 +949,17 @@ function ParamRow({
                 onChange={v => onChange({ invert: v || undefined })} />
       )}
 
-      {isFilter && (
+      {isGainFilter && (
+        <Slider
+          label="gain (dB)"
+          value={spec.gain ?? 0}
+          min={-18}
+          max={18}
+          step={0.1}
+          onChange={v => onChange({ gain: v })}
+        />
+      )}
+      {isFilter && !isShelf && (
         <Slider
           label="Q (resonance)"
           value={spec.q ?? 0.7}

--- a/src/world/audio/bus.ts
+++ b/src/world/audio/bus.ts
@@ -25,12 +25,19 @@ export interface ParamSpec {
   min?: number
   max?: number
   invert?: boolean
-  // Filter resonance — only meaningful for lowpass/highpass/bandpass
+  // Filter resonance — only meaningful for lowpass/highpass/bandpass/peaking
   // params. Default 0.7 (transparent in lowpass, gentle peak in
-  // bandpass). Higher Q = narrower filter, more emphasis at cutoff.
-  // Read at applyParams time so the editor's Q slider takes effect on
-  // next tick without rebuilding the BiquadFilter.
+  // bandpass, moderate bell width for peaking). Higher Q = narrower
+  // filter, more emphasis at cutoff. Read at applyParams time so the
+  // editor's Q slider takes effect on next tick without rebuilding the
+  // BiquadFilter.
   q?: number
+  // Filter gain in dB — only meaningful for shelves and peaking filters
+  // (#81 — 3-band EQ). 0 = transparent, ±18 typical range. Ignored by
+  // lowpass/highpass/bandpass (BiquadFilterNode.gain has no effect for
+  // those types). Static — not modulator-driven — for now; sweeping EQ
+  // gain is rare in practice and adds smoothing complexity.
+  gain?: number
 }
 
 // Re-export so the editor can construct/mutate specs without poking the
@@ -224,11 +231,25 @@ interface LoopRuntime {
 }
 
 // Build the BiquadFilters declared by a loop's params. Keys are the filter
-// type — a registry param named `lowpass` / `highpass` / `bandpass` becomes
-// the matching BiquadFilter, returned in a stable order so setFilters()
-// receives a deterministic chain (highpass → bandpass → lowpass = "trim
-// bottom, focus middle, trim top" in that order).
-const FILTER_NAMES = ['highpass', 'bandpass', 'lowpass'] as const
+// type — a registry param named `lowpass` / `highpass` / `bandpass` /
+// `lowshelf` / `peaking` / `highshelf` becomes the matching BiquadFilter,
+// returned in a stable mastering order so setFilters() receives a
+// deterministic chain: cut bottom → shelf bottom → focus middle → bell
+// middle → shelf top → cut top. Order matters because biquads are not
+// linear-phase: swapping a peak before/after a shelf changes the audible
+// sum on overlap regions.
+const FILTER_NAMES = ['highpass', 'lowshelf', 'bandpass', 'peaking', 'highshelf', 'lowpass'] as const
+// Defaults per filter type — transparent (0 dB / open Q / sensible centre)
+// so an unattached newly-added filter doesn't audibly snap before the
+// editor writes a real value.
+const FILTER_DEFAULTS: Record<typeof FILTER_NAMES[number], { freq: number; q: number }> = {
+  highpass:  { freq: 20,    q: 0.7 },
+  lowshelf:  { freq: 200,   q: 0.7 },   // Q ignored for shelves; left for API uniformity
+  bandpass:  { freq: 1000,  q: 0.7 },
+  peaking:   { freq: 1000,  q: 1.0 },
+  highshelf: { freq: 5000,  q: 0.7 },
+  lowpass:   { freq: 22000, q: 0.7 },
+}
 function buildFiltersForParams(ctx: AudioContext, params: Record<string, ParamSpec> | undefined): { nodes: BiquadFilterNode[]; map: Record<string, BiquadFilterNode> } {
   const map: Record<string, BiquadFilterNode> = {}
   const nodes: BiquadFilterNode[] = []
@@ -237,10 +258,11 @@ function buildFiltersForParams(ctx: AudioContext, params: Record<string, ParamSp
     if (!params[name]) continue
     const f = ctx.createBiquadFilter()
     f.type = name as BiquadFilterType
-    // Sensible defaults so the filter is transparent until applyParams writes
-    // a real value (avoids a brief silence on attach if mod is mid-range).
-    f.frequency.value = name === 'lowpass' ? 22000 : name === 'highpass' ? 20 : 1000
-    f.Q.value = 0.7
+    const d = FILTER_DEFAULTS[name]
+    f.frequency.value = d.freq
+    f.Q.value = d.q
+    // gain.value defaults to 0 dB (transparent) — shelves/peaking pick it
+    // up from spec.gain in applyParams. Cut filters ignore it natively.
     map[name] = f
     nodes.push(f)
   }
@@ -513,11 +535,25 @@ class AudioBus {
    *  Mutates BOTH the runtime def (what applyParams reads) AND the
    *  audioLive entry (what the Commit button bakes into audio.json),
    *  so the two never drift mid-session.
+   *
+   *  When the spec being added is a filter type that isn't yet in the
+   *  loop's BiquadFilter chain (lr.filters), the chain is rebuilt
+   *  in-place via setFilters() — without this, `addParam('peaking')` etc.
+   *  would land the spec in audioLive (so Commit persists it) but leave
+   *  the audible chain unchanged until the next page reload. Fixes a
+   *  latent #54-era gap, also unblocks the #81 EQ "Add band" UX.
    */
   setLoopParamSpec(key: string, name: string, spec: ParamSpec) {
     const lr = this.loops.get(key)
     if (lr) {
       lr.def.params = { ...(lr.def.params ?? {}), [name]: { ...spec } }
+      // If `name` is a filter type and that filter isn't already wired,
+      // rebuild the chain. applyParams's "if (filt) {...}" branch on its
+      // next tick will then pick up the spec's freq/Q/gain.
+      const isFilter = (FILTER_NAMES as readonly string[]).includes(name)
+      if (isFilter && !(lr.filters && lr.filters[name])) {
+        this.rebuildLoopFilters(lr)
+      }
     }
     // audioLive is the editor's commit source; keep it in sync. Search
     // both static loops + runtimeLoops so glb-imported KHR_audio_emitter
@@ -531,11 +567,36 @@ class AudioBus {
     }
   }
 
+  /** Rebuild the BiquadFilter chain for a loop from its current params and
+   *  attach it via THREE.Audio.setFilters(). In-place — the audio source
+   *  node stays connected; only the inserted filters change. Safe to call
+   *  with no listener (no-op until attach). Sample loops only; synth loops
+   *  use their own param routing, not this chain. */
+  private rebuildLoopFilters(lr: LoopRuntime) {
+    if (!this.listener || !lr.node) return
+    const ctx = this.listener.context
+    const built = buildFiltersForParams(ctx, lr.def.params)
+    lr.filters = built.map
+    // setFilters() accepts BiquadFilterNode[] per its declared type. THREE
+    // re-wires the chain (source → filters → gain → destination) cleanly.
+    try { lr.node.setFilters(built.nodes) } catch { /* synth or detached — ignore */ }
+  }
+
   /** Read the current runtime def for a loop. Editor uses this to
    *  populate sliders with what applyParams is actually using right
    *  now (post any setLoopParamSpec edits). */
   getLoopRuntimeDef(key: string): LoopDef | undefined {
     return this.loops.get(key)?.def
+  }
+
+  /** Filter-type keys currently wired into the loop's BiquadFilter chain
+   *  (e.g. ['highpass', 'peaking', 'lowpass']). Distinct from the spec
+   *  set in audioLive — a key here means a BiquadFilterNode is actually
+   *  in the audible signal path, not just persisted for commit. Returns
+   *  [] for unregistered keys or pre-attach. */
+  getLoopFilterNames(key: string): string[] {
+    const lr = this.loops.get(key)
+    return lr?.filters ? Object.keys(lr.filters) : []
   }
 
   setWindStrengthSource(fn: () => number) {
@@ -925,15 +986,18 @@ class AudioBus {
         continue
       }
 
-      // Filter params (lowpass / highpass / bandpass) — smooth-sweep the
-      // sample-loop's BiquadFilter, OR a synth-exposed AudioParam. Q
-      // updates apply on the same tick — bus reads spec.q each frame so
-      // the editor's slider is heard immediately, with the same smoothSet
-      // ramp as frequency to avoid zipper noise on rapid drags.
+      // Filter params (lowpass / highpass / bandpass / lowshelf / peaking
+      // / highshelf) — smooth-sweep the sample-loop's BiquadFilter, OR a
+      // synth-exposed AudioParam. Q + gain updates apply on the same tick
+      // — bus reads spec.q / spec.gain each frame so the editor's sliders
+      // are heard immediately, with the same smoothSet ramp as frequency
+      // to avoid zipper noise on rapid drags. gain is dB (Web Audio
+      // native unit for BiquadFilterNode.gain); cut filters ignore it.
       const filt = lr.filters?.[name]
       if (filt) {
         smoothSet(filt.frequency, value, ctx, SMOOTH_HORIZON_FILT)
         if (spec.q != null) smoothSet(filt.Q, spec.q, ctx, SMOOTH_HORIZON_FILT)
+        if (spec.gain != null) smoothSet(filt.gain, spec.gain, ctx, SMOOTH_HORIZON_FILT)
         continue
       }
       const ap = lr.synth?.params?.[name]

--- a/tests/audio-eq-3band.mjs
+++ b/tests/audio-eq-3band.mjs
@@ -1,0 +1,113 @@
+// Observe #81: adding EQ bands (lowshelf / peaking / highshelf) via the
+// editor wires real BiquadFilterNodes into the loop's audible chain AND
+// updates the frequency-response canvas.
+//
+// Targets whatever loop the Inspector currently shows (the editor may
+// auto-select the axis_rotation rumble loop on boot via #78) so the
+// canvas assertion reflects the same sound we edit.
+//
+// Two observations:
+//   A) After setLoopParamSpec for a NEW filter type, the chain rebuild
+//      happens — getLoopFilterNames(key) includes the new type. Proves
+//      the latent #54 gap is closed (pre-fix, adding a filter was a
+//      silent no-op until reload).
+//   B) The FrequencyResponseCanvas paints a non-empty blue curve once an
+//      EQ band is active.
+import { chromium } from 'playwright'
+
+const URL = 'http://localhost:7003/edit/levels/lvl_1/audio'
+
+const results = []
+const ok = (label, cond, detail = '') => results.push({ label, pass: !!cond, detail })
+
+const browser = await chromium.launch({ headless: true })
+const page = await browser.newPage()
+await page.goto(URL, { waitUntil: 'domcontentloaded' })
+await page.waitForFunction(() => !!(window).__audioBus, null, { timeout: 15000 })
+await page.waitForTimeout(1000)
+
+// The live scene in the editor keeps auto-selecting axis_rotation (the
+// rotation rumble publishes to lastTriggered — #78). Lock selection so the
+// Inspector stays put on whatever's shown, making the canvas assertion
+// deterministic.
+await page.evaluate(() => {
+  const cb = [...document.querySelectorAll('input[type="checkbox"]')]
+    .find(c => c.parentElement?.textContent?.includes('Lock selection'))
+  if (cb && !(cb).checked) (cb).click()
+})
+await page.waitForTimeout(700)
+
+// Read the loop key the Inspector is currently showing (its first child div).
+const selectedKey = await page.evaluate(() => {
+  const btn = [...document.querySelectorAll('button')].find(b => b.textContent?.trim() === 'Replace sample…')
+  let pane = btn?.parentElement
+  while (pane && pane.parentElement && getComputedStyle(pane).overflowY !== 'auto') pane = pane.parentElement
+  // strip the trailing "Reset to default" button text the header row carries
+  return pane?.children?.[0]?.textContent?.trim().replace(/Reset to default$/, '') ?? null
+})
+ok('Inspector is showing a loop', !!selectedKey && /^[a-z_]+$/.test(selectedKey), `key=${selectedKey}`)
+
+// Make sure the loop is registered so the chain rebuild has a node.
+await page.evaluate((k) => {
+  const b = (window).__audioBus
+  const def = b.getLoopRuntimeDef(k)
+  if (def) b.registerLoop(def)
+}, selectedKey)
+await page.waitForTimeout(400)
+
+// --- A) chain rebuild on add ---
+const beforeNames = await page.evaluate((k) => (window).__audioBus.getLoopFilterNames(k), selectedKey)
+ok('before: peaking not in chain', !beforeNames.includes('peaking'), `chain=${JSON.stringify(beforeNames)}`)
+
+await page.evaluate((k) => {
+  (window).__audioBus.setLoopParamSpec(k, 'peaking', { base: 1000, gain: 12, q: 2 })
+}, selectedKey)
+await page.waitForTimeout(200)
+
+const afterNames = await page.evaluate((k) => (window).__audioBus.getLoopFilterNames(k), selectedKey)
+ok('after add peaking: chain rebuilt to include it', afterNames.includes('peaking'), `chain=${JSON.stringify(afterNames)}`)
+
+const spec = await page.evaluate((k) => (window).__audioBus.getLoopRuntimeDef(k)?.params?.peaking, selectedKey)
+ok('peaking spec persisted: gain 12 dB @ 1000 Hz, Q=2',
+   spec?.base === 1000 && spec?.gain === 12 && spec?.q === 2, `got ${JSON.stringify(spec)}`)
+
+await page.evaluate((k) => {
+  (window).__audioBus.setLoopParamSpec(k, 'lowshelf', { base: 200, gain: -6 })
+}, selectedKey)
+await page.waitForTimeout(200)
+const stackedNames = await page.evaluate((k) => (window).__audioBus.getLoopFilterNames(k), selectedKey)
+ok('after add lowshelf: chain has BOTH peaking + lowshelf',
+   stackedNames.includes('peaking') && stackedNames.includes('lowshelf'), `chain=${JSON.stringify(stackedNames)}`)
+
+// --- B) FrequencyResponseCanvas paints a curve ---
+// Wait through a couple of the workspace's 500ms heartbeats so ParamsEditor
+// re-reads the now-EQ'd params and repaints the canvas.
+await page.waitForTimeout(1200)
+const canvasInfo = await page.evaluate(() => {
+  const header = [...document.querySelectorAll('div')].find(d => d.textContent?.trim() === 'Frequency response')
+  if (!header) return { found: false, reason: 'no Frequency response label' }
+  const canvas = header.parentElement?.querySelector('canvas')
+  if (!(canvas instanceof HTMLCanvasElement)) return { found: false, reason: 'no canvas in section' }
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return { found: false, reason: 'no 2d ctx' }
+  const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data
+  let curvePixels = 0
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i], g = data[i + 1], b = data[i + 2], a = data[i + 3]
+    if (a > 0 && r > 80 && r < 180 && g > 130 && g < 200 && b > 200) curvePixels++
+  }
+  return { found: true, curvePixels }
+})
+ok('FrequencyResponseCanvas painted a non-empty curve',
+   canvasInfo.found && canvasInfo.curvePixels > 10, `info=${JSON.stringify(canvasInfo)}`)
+
+await browser.close()
+
+console.log('\n=== 3-band EQ observation ===\n')
+let allPass = true
+for (const r of results) {
+  console.log(`  ${r.pass ? '✓' : '✗'} ${r.label}${!r.pass && r.detail ? '  (' + r.detail + ')' : ''}`)
+  if (!r.pass) allPass = false
+}
+console.log(`\n${allPass ? 'ALL PASS' : 'FAILURES PRESENT'}\n`)
+process.exit(allPass ? 0 : 1)


### PR DESCRIPTION
Closes #81.

## Summary

Per-sound **3-band parametric EQ** (low shelf + mid peak + high shelf) with a live frequency-response preview, for loops. Builds on the BiquadFilter chain already plumbed for loops.

- **New filter types** `lowshelf` / `peaking` / `highshelf` added to the chain in mastering order (`highpass → lowshelf → bandpass → peaking → highshelf → lowpass`). `ParamSpec.gain` (dB) added; `applyParams` ramps it like freq/Q.
- **Editor**: `+ Lowshelf / + Peaking / + Highshelf` buttons; ParamRow shows a gain (dB) slider for gainy filters, hides Q for shelves.
- **FrequencyResponseCanvas**: combined chain magnitude via `getFrequencyResponse()`, dB-summed, log-x 20 Hz–20 kHz, repaints live as sliders move. Single shared `OfflineAudioContext` (browsers cap AudioContexts per page).

## 🐛 Also fixes a latent bug (was #54-era)

`setLoopParamSpec` never rebuilt the live BiquadFilter chain — so adding **any** filter via the editor (old cut filters too) was a silent no-op until page reload: the spec persisted to `audio.json` but produced no audible change. Now the chain rebuilds in-place (`rebuildLoopFilters` → `setFilters`) the moment a not-yet-wired filter type is added. New `getLoopFilterNames(key)` exposes the actually-wired chain.

## Test plan

- [x] `tests/audio-eq-3band.mjs` — adds peaking + lowshelf to the shown loop, asserts **both wire into the audible chain** (`getLoopFilterNames`), the spec persists with gain/Q, and the response canvas paints a non-empty curve (pixel-read). **ALL PASS.**
- [x] `tsc --noEmit` clean.
- [x] No new eslint errors (one intentional exhaustive-deps disable on the live-repaint effect).

## Notes / follow-ups

- **MVP is loops only.** Events (`BufferSource → eventGain`) have no filter chain — per-event EQ needs new plumbing; will file once this lands.
- **Surfaced UX wrinkle:** in the editor the live scene keeps auto-selecting `axis_rotation` (the rotation rumble publishing to `lastTriggered`, #78), which steals selection from whatever you're editing. The "Lock selection" toggle mitigates it, but the default behavior is distracting — worth a follow-up (debounce, or don't auto-select while the inspector is being actively edited).