### PR TITLE
🎯 Audio editor: scene rotation no longer steals Inspector selection mid-edit

### DIFF
--- a/src/AudioEditorRoute.tsx
+++ b/src/AudioEditorRoute.tsx
@@ -160,11 +160,16 @@ function AudioWorkspace() {
   }, [])
   void tick
 
-  // Dev-only handle to the audio bus — mirrors window.__planet. Lets
-  // Playwright read/seed bus state without DOM scraping. Stripped in prod.
+  // Dev-only handles for tests / live debugging — mirror window.__planet.
+  // __audioBus: bus singleton (set/read params, registered chain, overrides).
+  // __lastTriggered: editor's auto-select source — lets tests bypass the
+  // scene and publish keys directly, exercising the auto-select + grace
+  // logic in isolation (#84). Stripped in prod.
   useEffect(() => {
     if (import.meta.env.DEV) {
-      ;(window as unknown as { __audioBus?: typeof audioBus }).__audioBus = audioBus
+      const w = window as unknown as { __audioBus?: typeof audioBus; __lastTriggered?: typeof useLastTriggered }
+      w.__audioBus = audioBus
+      w.__lastTriggered = useLastTriggered
     }
   }, [])
 
@@ -179,12 +184,37 @@ function AudioWorkspace() {
     entries[0]?.def.key ?? null,
   )
   const lockSelection = useRef(false)
+  // Inspector-interaction grace window (#84). The embedded live scene keeps
+  // re-triggering axis_rotation via #78, which yanks the Inspector to that
+  // row mid-edit. Bumped on any pointerdown/keydown inside the Inspector
+  // pane; the auto-select effect skips publishes that arrive while the user
+  // is "warm" so a slider drag isn't interrupted. Resumes after idle —
+  // first-time discoverability ("rotate → see the sound") still works.
+  const lastInteractRef = useRef(0)
+  const INSPECTOR_INTERACT_GRACE_MS = 3000
+  const noteInspectorInteract = useCallback(() => {
+    lastInteractRef.current = Date.now()
+  }, [])
+  // Manual list-row click is user intent — make it sticky for the grace
+  // window too, so the scene can't steal selection back right after.
+  const selectManually = useCallback((key: string) => {
+    setSelectedKey(key)
+    lastInteractRef.current = Date.now()
+  }, [])
+  // DEV-only mirror of the grace timestamp for tests / debugging.
+  useEffect(() => {
+    if (!import.meta.env.DEV) return
+    const w = window as unknown as { __audioEditor?: { lastInteractAt: () => number } }
+    w.__audioEditor = { lastInteractAt: () => lastInteractRef.current }
+  }, [])
 
-  // Auto-select on lastTriggered fire (unless lock toggle is on).
+  // Auto-select on lastTriggered fire (unless lock toggle is on, OR the
+  // user just touched the Inspector — see lastInteractRef).
   const lastKey = useLastTriggered(s => s.key)
   const lastN = useLastTriggered(s => s.n)
   useEffect(() => {
     if (lockSelection.current) return
+    if (Date.now() - lastInteractRef.current < INSPECTOR_INTERACT_GRACE_MS) return
     if (lastKey) setSelectedKey(lastKey)
   }, [lastKey, lastN])
 
@@ -273,12 +303,13 @@ function AudioWorkspace() {
         <EventList
           entries={entries}
           selectedKey={selected?.def.key ?? null}
-          onSelect={setSelectedKey}
+          onSelect={selectManually}
           lockSelection={lockSelection}
         />
         <Inspector
           entry={selected}
           onReset={onResetEntry}
+          onInteract={noteInspectorInteract}
           key={`${selected?.def.key ?? 'none'}:${resetNonce}`}
         />
       </div>
@@ -418,17 +449,25 @@ function EventList({
 
 // ── Inspector ──────────────────────────────────────────────────────────
 
-function Inspector({ entry, onReset }: { entry: Entry | null; onReset: (entry: Entry) => void }) {
+function Inspector({ entry, onReset, onInteract }: {
+  entry: Entry | null
+  onReset: (entry: Entry) => void
+  /** Bumped on every pointerdown/keydown inside this pane (#84 grace
+   *  window). Capture phase so it fires even if a child stops propagation. */
+  onInteract?: () => void
+}) {
   if (!entry) {
     return (
-      <div style={{ flex: '1 1 50%', padding: 16, opacity: 0.5, fontStyle: 'italic' }}>
+      <div style={{ flex: '1 1 50%', padding: 16, opacity: 0.5, fontStyle: 'italic' }}
+           onPointerDownCapture={onInteract} onKeyDownCapture={onInteract}>
         No entry selected.
       </div>
     )
   }
   const canReset = audioBus.hasRegistryDefault(entry.def.key)
   return (
-    <div style={{ flex: '1 1 50%', minHeight: 200, padding: 12, overflowY: 'auto' }}>
+    <div style={{ flex: '1 1 50%', minHeight: 200, padding: 12, overflowY: 'auto' }}
+         onPointerDownCapture={onInteract} onKeyDownCapture={onInteract}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, marginBottom: 8 }}>
         <span style={{ fontSize: 13, fontWeight: 600 }}>{entry.def.key}</span>
         <button

--- a/tests/audio-inspector-grace.mjs
+++ b/tests/audio-inspector-grace.mjs
@@ -1,0 +1,62 @@
+// Observe #84: clicking a list row routes through `selectManually` which
+// updates BOTH the selection AND the grace timestamp (`lastInteractRef`).
+// The full timing behavior (grace blocking scene auto-publishes for 3 s)
+// is verified by code review — Playwright + the live WebGL scene make
+// each `evaluate` round-trip several wall-clock seconds long, so any
+// timing-sensitive assertion is unreliable.
+//
+// What this test proves (regression guard for #84):
+//   - Row click flips selection (the existing onSelect path works).
+//   - The grace timestamp goes from 0 (initial) to a finite positive number
+//     in the same tick — proving the selectManually wiring is in place,
+//     not the older bare setSelectedKey.
+import { chromium } from 'playwright'
+
+const URL = 'http://localhost:7001/edit/levels/lvl_1/audio'
+
+const results = []
+const ok = (label, cond, detail = '') => results.push({ label, pass: !!cond, detail })
+
+const browser = await chromium.launch({ headless: true })
+const page = await browser.newPage()
+await page.goto(URL, { waitUntil: 'domcontentloaded' })
+await page.waitForFunction(
+  () => !!(window).__audioEditor,
+  null, { timeout: 15000 },
+)
+await page.waitForTimeout(1200)
+
+const beforeTs = await page.evaluate(() => (window).__audioEditor.lastInteractAt())
+ok('grace timestamp is 0 before any interaction', beforeTs === 0, `got ${beforeTs}`)
+
+await page.evaluate(() => {
+  const row = [...document.querySelectorAll('div')].find(d => {
+    const c = d.children
+    return c.length === 2 && c[0]?.tagName === 'SPAN' && c[1]?.tagName === 'SPAN'
+        && c[0].textContent === 'EVT' && c[1].textContent === 'footstep'
+  })
+  row?.click()
+})
+
+const inspKey = await page.evaluate(() => {
+  const btn = [...document.querySelectorAll('button')].find(b => b.textContent?.trim() === 'Replace sample…')
+  let pane = btn?.parentElement
+  while (pane && pane.parentElement && getComputedStyle(pane).overflowY !== 'auto') pane = pane.parentElement
+  return pane?.children?.[0]?.textContent?.trim().replace(/Reset to default$/, '') ?? null
+})
+ok('row click flips selection to footstep', inspKey === 'footstep', `got ${inspKey}`)
+
+const afterTs = await page.evaluate(() => (window).__audioEditor.lastInteractAt())
+ok('row click bumped grace timestamp (selectManually wired)',
+   afterTs > 0 && afterTs !== beforeTs, `before=${beforeTs} after=${afterTs}`)
+
+await browser.close()
+
+console.log('\n=== inspector interaction grace — wiring guard ===\n')
+let allPass = true
+for (const r of results) {
+  console.log(`  ${r.pass ? '✓' : '✗'} ${r.label}${!r.pass && r.detail ? '  (' + r.detail + ')' : ''}`)
+  if (!r.pass) allPass = false
+}
+console.log(`\n${allPass ? 'ALL PASS' : 'FAILURES PRESENT'}\n`)
+process.exit(allPass ? 0 : 1)


### PR DESCRIPTION
Closes #84.

## Problem

The editor's embedded live scene **continuously publishes `axis_rotation`** to `lastTriggered` — verified by probe, ~1 publish/second even with no user input (the slice-rotation rumble fires on its own as part of the scene loop). The auto-select effect (#78) flips the Inspector to whatever's published, so:

- Dragging a slider → axis_rotation gets published → Inspector jumps to that row mid-drag.
- Clicking another row → same: stolen within a second.

"Lock selection" became *required* just to keep editing without interruption.

## Fix

Three-second **interaction grace window**:

- Inspector wraps its root with `onPointerDownCapture` / `onKeyDownCapture` → both bump a `lastInteractRef` timestamp. Capture phase so child `stopPropagation` can't bypass it.
- Manual list-row click goes through a new `selectManually` (replaces bare `setSelectedKey` on `onSelect`) which updates the selection **and** bumps the timestamp.
- The auto-select effect adds one line: skip if `Date.now() - lastInteractRef.current < 3000`.

**First-time discoverability still works** (rotate a slice → axis_rotation row lights up) — grace only activates once you've touched the Inspector. **Lock Selection toggle remains** as the permanent escape hatch.

## Test plan

- [x] `tests/audio-inspector-grace.mjs` — wiring guard: row click flips selection AND bumps the grace timestamp through `selectManually` (not the bare `setSelectedKey`). **ALL PASS.**
- [x] `tsc --noEmit` clean.
- [x] The 3 s timing behavior itself is a 3-line code-review item — see notes.

## Notes

- A full E2E timing assertion (grace blocks ongoing publishes for 3 s then resumes) proved unreliable under Playwright + WebGL: each `page.evaluate` round-trip can take several wall-clock seconds when the 3D scene is hammering the compositor, so a "wait N ms then check" assertion regularly sees wall-clock 30 s+ elapsed and grace expired. The test is therefore scoped to wiring; the timing logic is verified by inspection.
- Added DEV-only `window.__lastTriggered` and `window.__audioEditor.lastInteractAt()` (mirrors the existing `__audioBus`/`__planet` pattern) for tests + live debugging. Stripped in prod.