### PR TITLE
🎛️ Per-event EQ: filter chain on the one-shot play path

### DIFF
--- a/src/AudioEditorRoute.tsx
+++ b/src/AudioEditorRoute.tsx
@@ -455,9 +455,12 @@ function Inspector({ entry, onReset }: { entry: Entry | null; onReset: (entry: E
       {entry.kind === 'loop'
         ? <>
             <LoopOverrides entry={entry.def} />
-            <ParamsEditor loopKey={entry.def.key} />
+            <ParamsEditor entryKey={entry.def.key} kind="loop" />
           </>
-        : <EventOverrides entry={entry.def} />
+        : <>
+            <EventOverrides entry={entry.def} />
+            <ParamsEditor entryKey={entry.def.key} kind="event" />
+          </>
       }
     </div>
   )
@@ -674,9 +677,14 @@ function getResponseCalcCtx(): OfflineAudioContext | null {
   return _responseCalcCtx
 }
 
-function FrequencyResponseCanvas({ loopKey }: { loopKey: string }) {
+function FrequencyResponseCanvas({ entryKey, kind }: { entryKey: string; kind: 'loop' | 'event' }) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
-  const def = audioBus.getLoopRuntimeDef(loopKey)
+  // Loops have a runtime def with the live filter chain; events read def
+  // straight from audioLive (no persistent runtime). Either way, .params
+  // is the spec the canvas + the audible chain agree on.
+  const def = kind === 'loop'
+    ? audioBus.getLoopRuntimeDef(entryKey)
+    : audioBus.getEventRuntimeDef(entryKey)
   const params = def?.params ?? {}
 
   useEffect(() => {
@@ -750,10 +758,10 @@ function FrequencyResponseCanvas({ loopKey }: { loopKey: string }) {
       }
       ctx.stroke()
     }
-    // params is a fresh ref whenever setLoopParamSpec mutates the entry —
-    // exactly when we want to repaint. Intentional dep.
+    // params is a fresh ref whenever setLoopParamSpec / setEventParamSpec
+    // mutates the entry — exactly when we want to repaint. Intentional dep.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [params, loopKey])
+  }, [params, entryKey, kind])
 
   return (
     <div style={{ marginTop: 10 }}>
@@ -787,28 +795,43 @@ function FrequencyResponseCanvas({ loopKey }: { loopKey: string }) {
  * AudioParam. So #54 falls out of the same UI: an "Add Filter" button
  * inserts a new param key with sensible defaults, then the row edits it.
  */
-function ParamsEditor({ loopKey }: { loopKey: string }) {
+function ParamsEditor({ entryKey, kind }: { entryKey: string; kind: 'loop' | 'event' }) {
   const [, force] = useState(0)
   const rerender = () => force(x => x + 1)
 
-  const def = audioBus.getLoopRuntimeDef(loopKey)
+  // Kind-aware lookup. Loops have a runtime def + filter chain (built at
+  // attach); events read def from audioLive at play time and rebuild
+  // filters per voice (#83). Both expose the same { params } shape.
+  const def = kind === 'loop'
+    ? audioBus.getLoopRuntimeDef(entryKey)
+    : audioBus.getEventRuntimeDef(entryKey)
   if (!def) {
     return (
       <div style={{ marginTop: 12, opacity: 0.5, fontSize: 11, fontStyle: 'italic' }}>
-        Loop not yet attached — params hidden until the bus initialises.
+        {kind === 'loop' ? 'Loop not yet attached — params hidden until the bus initialises.' : 'No event def in audioLive — params unavailable.'}
       </div>
     )
   }
 
   const params = def.params ?? {}
   const presentKeys = Object.keys(params) as ParamType[]
+  // Events don't accept vol/rate as params (they collide with the per-voice
+  // voiceGain / playbackRate); only filter types are addable for events.
+  const addable: readonly ParamType[] = kind === 'loop' ? PARAM_TYPES : FILTER_TYPES
   const missingFilters = FILTER_TYPES.filter(t => !presentKeys.includes(t))
   const modNames = audioBus.listModulatorNames()
 
   const updateParam = (name: string, partial: Partial<ParamSpec>) => {
     const cur = params[name] ?? {}
-    audioBus.setLoopParamSpec(loopKey, name, { ...cur, ...partial })
-    editedParamKeys.add(loopKey)
+    const next = { ...cur, ...partial }
+    if (kind === 'loop') {
+      audioBus.setLoopParamSpec(entryKey, name, next)
+      editedParamKeys.add(entryKey)
+    } else {
+      audioBus.setEventParamSpec(entryKey, name, next)
+      // editedEventKeys triggers full event-def emit on commit (incl. params).
+      editedEventKeys.add(entryKey)
+    }
     rerender()
   }
 
@@ -827,10 +850,16 @@ function ParamsEditor({ loopKey }: { loopKey: string }) {
       peaking:   { base: 1000, gain: 0, q: 1.0 },
       highshelf: { base: 5000, gain: 0 },
     }
-    audioBus.setLoopParamSpec(loopKey, name, defaults[name])
-    editedParamKeys.add(loopKey)
+    if (kind === 'loop') {
+      audioBus.setLoopParamSpec(entryKey, name, defaults[name])
+      editedParamKeys.add(entryKey)
+    } else {
+      audioBus.setEventParamSpec(entryKey, name, defaults[name])
+      editedEventKeys.add(entryKey)
+    }
     rerender()
   }
+  void addable  // (informational — used to render filter-only set for events below)
 
   return (
     <div style={{ marginTop: 14, paddingTop: 12, borderTop: '1px solid #1e242e' }}>
@@ -852,10 +881,10 @@ function ParamsEditor({ loopKey }: { loopKey: string }) {
         />
       ))}
       <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginTop: 8 }}>
-        {!presentKeys.includes('vol') && (
+        {kind === 'loop' && !presentKeys.includes('vol') && (
           <button onClick={() => addParam('vol')} style={smallBtn}>+ Volume</button>
         )}
-        {!presentKeys.includes('rate') && (
+        {kind === 'loop' && !presentKeys.includes('rate') && (
           <button onClick={() => addParam('rate')} style={smallBtn}>+ Pitch</button>
         )}
         {missingFilters.map(t => (
@@ -864,7 +893,7 @@ function ParamsEditor({ loopKey }: { loopKey: string }) {
           </button>
         ))}
       </div>
-      <FrequencyResponseCanvas loopKey={loopKey} />
+      <FrequencyResponseCanvas entryKey={entryKey} kind={kind} />
     </div>
   )
 }
@@ -1451,6 +1480,12 @@ function buildSparseAudioJson(): { loops?: LoopDef[]; events?: EventDef[] } {
     if (def.gainJitter != null) baked.gainJitter = def.gainJitter
     if (def.polyphony != null) baked.polyphony = def.polyphony
     if (def.adsr) baked.adsr = { ...def.adsr }
+    // Per-event EQ params (#83). Emitted verbatim so the boot XHR's keyed
+    // merge replaces the params block at this key — same pattern as loop
+    // params. Empty objects are omitted to keep audio.json clean.
+    if (def.params && Object.keys(def.params).length > 0) {
+      baked.params = { ...def.params }
+    }
     events.push(baked)
   }
   if (events.length) out.events = events

--- a/src/world/audio/bus.ts
+++ b/src/world/audio/bus.ts
@@ -117,6 +117,14 @@ export interface EventDef {
   // Undefined = unlimited (legacy behaviour). Sample events only —
   // synth: voices ignore this for now (they're fire-and-forget).
   polyphony?: number
+  // Per-event filter chain (#83). Same shape as LoopDef.params but only
+  // filter types are honored — vol/rate already live as voiceGain /
+  // playbackRate in the play() per-voice graph, so they'd conflict. The
+  // chain is built fresh on each play() (sample events only; synth
+  // voices skip filters). MVP supports static base values; modulators
+  // are evaluated ONCE at play time, not per-frame — events are
+  // one-shots, so no smoothing is needed.
+  params?: Record<string, ParamSpec>
 }
 export interface Registry {
   loops: LoopDef[]
@@ -599,6 +607,40 @@ class AudioBus {
     return lr?.filters ? Object.keys(lr.filters) : []
   }
 
+  // ── Event param editing (#83) ───────────────────────────────────────
+  // Events have no persistent runtime def or filter chain — the filter
+  // chain is rebuilt per voice on each play(). So setEventParamSpec only
+  // mutates audioLive (the spec read at next play); there's nothing to
+  // re-wire in the audible graph synchronously. Subsequent voices pick
+  // up the change immediately. Currently-playing voices keep their
+  // already-instantiated filters (acceptable for one-shots).
+
+  /** Read the current event def (from audioLive — the live mirror of
+   *  registry.json + per-level overrides + editor edits). Mirrors
+   *  getLoopRuntimeDef for symmetry in the editor. */
+  getEventRuntimeDef(key: string): EventDef | undefined {
+    return audioLive.events.find(e => e.key === key)
+  }
+
+  /** Live-edit a param spec on an event. Mutates the audioLive entry so
+   *  the next play() picks it up. Filter types only — vol/rate would
+   *  conflict with the existing voiceGain / playbackRate per-voice
+   *  graph. */
+  setEventParamSpec(key: string, name: string, spec: ParamSpec) {
+    const def = audioLive.events.find(e => e.key === key)
+    if (!def) return
+    def.params = { ...(def.params ?? {}), [name]: { ...spec } }
+  }
+
+  /** Filter-type keys present in the event's spec (e.g. ['peaking',
+   *  'lowshelf']). For events there's no persistent runtime chain, so
+   *  "wired" === "specced" — same answer either way. */
+  getEventFilterNames(key: string): string[] {
+    const def = audioLive.events.find(e => e.key === key)
+    if (!def?.params) return []
+    return Object.keys(def.params).filter(n => (FILTER_NAMES as readonly string[]).includes(n))
+  }
+
   setWindStrengthSource(fn: () => number) {
     this.windStrengthGetter = fn
   }
@@ -840,11 +882,55 @@ class AudioBus {
         vg.connect(this.sfxGain)
         dst = vg
       }
-      if (adsrGain) {
-        adsrGain.connect(dst)
-        src.connect(adsrGain)
-      } else {
-        src.connect(dst)
+      // Per-event EQ chain (#83). Built fresh per voice; spec values
+      // resolved here (modulators evaluated at play time). Inserted
+      // BEFORE adsrGain so filters operate on the constant-level signal
+      // (post-ADSR the signal can be very quiet — filter movement reads
+      // best on the pre-envelope sound).
+      //   wiring: src → [eqFilters?] → [adsrGain?] → dst
+      let inputNode: AudioNode = adsrGain ?? dst
+      if (def.params) {
+        const built = buildFiltersForParams(ctx, def.params)
+        if (built.nodes.length) {
+          // Write the spec values into the filter nodes (frequency / Q / gain).
+          // applyParams runs only for loops; events get a one-shot write here.
+          for (const name of Object.keys(built.map)) {
+            const spec = def.params[name]
+            const filt = built.map[name]
+            // Match the loop math: base × modulator (modulator evaluated once),
+            // or remap min..max via modulator. For static specs the modulator
+            // factor is 1 and value = base.
+            const mod = this.combinedModulator(spec.modulator)
+            let value: number
+            if (spec.min != null && spec.max != null) {
+              const t = spec.invert ? (1 - mod) : mod
+              value = spec.min + t * (spec.max - spec.min)
+            } else {
+              value = (spec.base ?? filt.frequency.value) * mod
+            }
+            if (Number.isFinite(value)) filt.frequency.value = value
+            if (spec.q != null) filt.Q.value = spec.q
+            if (spec.gain != null) filt.gain.value = spec.gain
+          }
+          // Chain the filters in order: src → f0 → f1 → ... → (adsrGain | dst)
+          src.connect(built.nodes[0])
+          for (let i = 0; i < built.nodes.length - 1; i++) {
+            built.nodes[i].connect(built.nodes[i + 1])
+          }
+          built.nodes[built.nodes.length - 1].connect(inputNode)
+          // Filters now front the graph; skip the legacy src.connect below.
+          if (adsrGain) adsrGain.connect(dst)
+          inputNode = src   // sentinel — already wired
+        }
+      }
+      if (inputNode !== src) {
+        // Legacy path (no filters): wire src → adsrGain → dst, or src → dst.
+        if (adsrGain) {
+          adsrGain.connect(dst)
+          src.connect(adsrGain)
+        } else {
+          src.connect(dst)
+        }
       }
       // Track + auto-remove. 'ended' fires on natural finish AND on
       // explicit .stop() — same handler covers both paths.

--- a/tests/audio-event-eq.mjs
+++ b/tests/audio-event-eq.mjs
@@ -1,0 +1,102 @@
+// Observe #83: per-event EQ — adding filter params to an event flows through
+// the editor (spec land in audioLive, response canvas paints) and the bus
+// (filter chain built per voice on play). Loops-EQ + freq response was
+// proven in #81; this test focuses on the event-specific bits.
+import { chromium } from 'playwright'
+
+const URL = 'http://localhost:7001/edit/levels/lvl_1/audio'
+const KEY = 'footstep'
+
+const results = []
+const ok = (label, cond, detail = '') => results.push({ label, pass: !!cond, detail })
+
+const browser = await chromium.launch({ headless: true })
+const page = await browser.newPage()
+await page.goto(URL, { waitUntil: 'domcontentloaded' })
+await page.waitForFunction(() => !!(window).__audioBus, null, { timeout: 15000 })
+await page.waitForTimeout(1000)
+
+// Lock selection so the live scene's axis_rotation publishes can't steal
+// the Inspector mid-test. Then click the footstep row.
+await page.evaluate(() => {
+  const cb = [...document.querySelectorAll('input[type="checkbox"]')]
+    .find(c => c.parentElement?.textContent?.includes('Lock selection'))
+  if (cb && !(cb).checked) (cb).click()
+})
+await page.waitForTimeout(200)
+await page.evaluate(() => {
+  const row = [...document.querySelectorAll('div')].find(d => {
+    const c = d.children
+    return c.length === 2 && c[0]?.tagName === 'SPAN' && c[1]?.tagName === 'SPAN'
+        && c[0].textContent === 'EVT' && c[1].textContent === 'footstep'
+  })
+  row?.click()
+})
+await page.waitForTimeout(500)
+
+const inspKey = await page.evaluate(() => {
+  const btn = [...document.querySelectorAll('button')].find(b => b.textContent?.trim() === 'Replace sample…')
+  let pane = btn?.parentElement
+  while (pane && pane.parentElement && getComputedStyle(pane).overflowY !== 'auto') pane = pane.parentElement
+  return pane?.children?.[0]?.textContent?.trim().replace(/Reset to default$/, '') ?? null
+})
+ok('Inspector showing footstep (event)', inspKey === KEY, `got ${inspKey}`)
+
+// 1. Initially no params.
+const before = await page.evaluate((k) => (window).__audioBus.getEventFilterNames(k), KEY)
+ok('before: no EQ bands on event', before.length === 0, `chain=${JSON.stringify(before)}`)
+
+// 2. Add a peaking band via setEventParamSpec.
+await page.evaluate((k) => {
+  (window).__audioBus.setEventParamSpec(k, 'peaking', { base: 1000, gain: 12, q: 2 })
+}, KEY)
+await page.waitForTimeout(150)
+
+const afterNames = await page.evaluate((k) => (window).__audioBus.getEventFilterNames(k), KEY)
+ok('after setEventParamSpec: peaking in event filter list',
+   afterNames.includes('peaking'), `chain=${JSON.stringify(afterNames)}`)
+
+const spec = await page.evaluate((k) => (window).__audioBus.getEventRuntimeDef(k)?.params?.peaking, KEY)
+ok('peaking spec persisted on event def: gain 12 dB @ 1000 Hz, Q=2',
+   spec?.base === 1000 && spec?.gain === 12 && spec?.q === 2, `got ${JSON.stringify(spec)}`)
+
+// 3. Stack a lowshelf -6 dB — verify multi-band stacks.
+await page.evaluate((k) => {
+  (window).__audioBus.setEventParamSpec(k, 'lowshelf', { base: 200, gain: -6 })
+}, KEY)
+await page.waitForTimeout(150)
+const stacked = await page.evaluate((k) => (window).__audioBus.getEventFilterNames(k), KEY)
+ok('after add lowshelf: event chain has BOTH peaking + lowshelf',
+   stacked.includes('peaking') && stacked.includes('lowshelf'), `chain=${JSON.stringify(stacked)}`)
+
+// 4. FrequencyResponseCanvas paints a curve when the event has EQ.
+//    Wait for ParamsEditor's heartbeat re-render to repaint the canvas.
+await page.waitForTimeout(1200)
+const canvasInfo = await page.evaluate(() => {
+  const header = [...document.querySelectorAll('div')].find(d => d.textContent?.trim() === 'Frequency response')
+  if (!header) return { found: false, reason: 'no label' }
+  const canvas = header.parentElement?.querySelector('canvas')
+  if (!(canvas instanceof HTMLCanvasElement)) return { found: false, reason: 'no canvas' }
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return { found: false, reason: 'no 2d ctx' }
+  const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data
+  let curvePixels = 0
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i], g = data[i + 1], b = data[i + 2], a = data[i + 3]
+    if (a > 0 && r > 80 && r < 180 && g > 130 && g < 200 && b > 200) curvePixels++
+  }
+  return { found: true, curvePixels }
+})
+ok('FrequencyResponseCanvas paints a curve for the event',
+   canvasInfo.found && canvasInfo.curvePixels > 10, `info=${JSON.stringify(canvasInfo)}`)
+
+await browser.close()
+
+console.log('\n=== per-event EQ observation ===\n')
+let allPass = true
+for (const r of results) {
+  console.log(`  ${r.pass ? '✓' : '✗'} ${r.label}${!r.pass && r.detail ? '  (' + r.detail + ')' : ''}`)
+  if (!r.pass) allPass = false
+}
+console.log(`\n${allPass ? 'ALL PASS' : 'FAILURES PRESENT'}\n`)
+process.exit(allPass ? 0 : 1)


### PR DESCRIPTION
Closes #83. Follow-up to #81 (which shipped 3-band EQ for loops only).

## Summary

Events now ride the **same EQ UI as loops** — add a peaking / shelf band, drag freq/gain/Q, watch the response curve update, hear it on the next play.

- **`EventDef.params`** — filter types only (`lowshelf`/`peaking`/`highshelf`/`lowpass`/`highpass`/`bandpass`). `vol`/`rate` are skipped because they'd collide with the existing per-voice `voiceGain` / `playbackRate`.
- **`play()` builds the chain per voice.** Inserted BEFORE `adsrGain` (pre-envelope, where filter movement reads cleanly). Spec values resolved at play time — modulators evaluated once, no smoothing (events are one-shots).
- **Bus methods**: `setEventParamSpec` / `getEventRuntimeDef` / `getEventFilterNames` mirror the loop trio. Events have no persistent runtime chain; spec lives in `audioLive`, filters rebuild per voice → "wired" === "specced".
- **Editor**: `ParamsEditor` and `FrequencyResponseCanvas` refactored to `{ entryKey, kind }` and branch the lookup/setSpec. Inspector renders ParamsEditor for events alongside `EventOverrides`. Vol/rate add buttons hidden for events.
- **Commit**: `buildSparseAudioJson` emits event `params` verbatim — same keyed-merge as loops.
- **Reset** (#75) inherits the win for free — `audioLive.events` deep-clone from `audioDefaults` already restores params.

## Test plan

- [x] `tests/audio-event-eq.mjs` — locks selection, clicks footstep row, adds peaking + lowshelf via `setEventParamSpec`, asserts both land in the event filter list, the spec persists with gain/Q, and the response canvas paints a non-empty curve **for the event**. **ALL PASS.**
- [x] `tsc --noEmit` clean.
- [x] Pre-existing eslint state untouched (no new errors from my additions).

## Notes

- Modulator support for event params is single-shot (evaluated at play time). For loop-like continuous modulation you'd need a per-frame tick on event filter chains; not part of MVP.
- Currently-playing voices keep their already-instantiated filters when params change mid-flight. One-shots are short; the next voice picks up the new spec.