### PR TITLE
🎛️ Audio: axis rotation triplet — start/loop/end stingers (closes #87)

### DIFF
--- a/src/world/audio/registry.json
+++ b/src/world/audio/registry.json
@@ -68,11 +68,13 @@
     }
   ],
   "events": [
-    { "key": "footstep",   "anchor": "object:player", "src": "audio/footstep_grass.ogg", "pitchJitter": 0.08 },
-    { "key": "jump",       "anchor": "world",         "src": "audio/jump_grass.ogg" },
-    { "key": "tile_snap",  "anchor": "world",         "src": "synth:click" },
-    { "key": "solve",      "anchor": "world",         "src": "synth:chime" },
-    { "key": "menu_open",  "anchor": "world",         "src": "synth:click" },
-    { "key": "menu_close", "anchor": "world",         "src": "synth:click" }
+    { "key": "footstep",            "anchor": "object:player", "src": "audio/footstep_grass.ogg", "pitchJitter": 0.08 },
+    { "key": "jump",                "anchor": "world",         "src": "audio/jump_grass.ogg" },
+    { "key": "tile_snap",           "anchor": "world",         "src": "synth:click" },
+    { "key": "solve",               "anchor": "world",         "src": "synth:chime" },
+    { "key": "menu_open",           "anchor": "world",         "src": "synth:click" },
+    { "key": "menu_close",          "anchor": "world",         "src": "synth:click" },
+    { "key": "axis_rotation_start", "anchor": "world",         "src": "synth:click" },
+    { "key": "axis_rotation_end",   "anchor": "world",         "src": "synth:click" }
   ]
 }

--- a/src/world/audio/subscriptions.ts
+++ b/src/world/audio/subscriptions.ts
@@ -3,9 +3,10 @@
 // double-subscribe.
 //
 //   sliceRotationActive  — bus modulator: 1 while drag||anim, else 0.
-//                          Drives the axis_rotation rumble loop. The rumble
-//                          covers BOTH the drag and the commit-anim window
-//                          end-to-end — no separate one-shot stinger needed.
+//                          Drives the axis_rotation rumble loop. Rising and
+//                          falling edges also fire one-shot events
+//                          (axis_rotation_start / axis_rotation_end) for
+//                          crisp attack/release stingers on top of the loop.
 
 import { usePlanet } from '../store'
 import { audioBus } from './bus'
@@ -28,6 +29,11 @@ export function installAudioSubscriptions() {
     const active = (state.drag != null || state.anim != null) ? 1 : 0
     audioBus.setSliceRotationActive(active as 0 | 1)
     if (active === 1 && prevSliceActive === 0) {
+      // Attack stinger (#87): one-shot fires on top of the sustain loop.
+      // play() self-publishes via lastTriggered. Call FIRST so the manual
+      // publish below overwrites it — auto-select should land on the loop
+      // (the sustained thing the user tunes), not the stinger.
+      audioBus.play('axis_rotation_start')
       // Discoverability bridge (#77): the modulator-driven axis_rotation
       // loop has no audioBus.play() call to surface it in the audio editor.
       // Publishing on the rising edge lets the editor's auto-select +
@@ -35,6 +41,10 @@ export function installAudioSubscriptions() {
       // starts — same path as one-shot events. Once per gesture, not
       // continuously, so the flash doesn't strobe across drag frames.
       useLastTriggered.getState().publish('axis_rotation')
+    } else if (active === 0 && prevSliceActive === 1) {
+      // Release tail (#87): drag and anim both cleared — fire the end
+      // stinger as the loop's modulator-driven volume fades out.
+      audioBus.play('axis_rotation_end')
     }
     prevSliceActive = active
   })

--- a/tests/audio-rotation-triplet.mjs
+++ b/tests/audio-rotation-triplet.mjs
@@ -1,0 +1,85 @@
+// Observe #87: axis rotation now fires a triplet —
+//   axis_rotation_start (one-shot, rising edge of drag||anim)
+//   axis_rotation       (sustain loop, modulator-driven, unchanged)
+//   axis_rotation_end   (one-shot, falling edge)
+//
+// Spies on audioBus.play to capture which event keys fire, then drives
+// state.drag truthy/null to cross both edges. Once per gesture — the
+// rising-edge guard (prevSliceActive) is the load-bearing bit; if it
+// regressed the test would log dozens of starts on a single drag.
+//
+// Scoped to wiring observation (which keys fire, in what order) — not
+// audio output. Audible verification is sound-design work the user
+// does via SampleSwap in the editor.
+import { chromium } from 'playwright'
+
+const URL = 'http://localhost:7001/edit/levels/lvl_1/audio'
+
+const browser = await chromium.launch({ headless: true })
+const page = await browser.newPage()
+await page.goto(URL, { waitUntil: 'domcontentloaded' })
+await page.waitForFunction(() => !!(window).__planet && !!(window).__audioBus, null, { timeout: 15000 })
+
+// Spy on play() before any user interaction so we catch the very first
+// trigger. Push keys into an array we can drain from Node.
+await page.evaluate(() => {
+  const bus = (window).__audioBus
+  const calls = []
+  ;(window).__playCalls = calls
+  const orig = bus.play.bind(bus)
+  bus.play = (key, opts) => { calls.push(key); return orig(key, opts) }
+})
+
+await page.waitForTimeout(400)
+
+// Gesture 1: drag truthy → drag null. Crosses rising edge then falling edge.
+await page.evaluate(() => {
+  (window).__planet.setState({ drag: { axis: 'x', start: 0, slice: 0 } })
+})
+await page.waitForTimeout(200)
+await page.evaluate(() => {
+  (window).__planet.setState({ drag: null })
+})
+await page.waitForTimeout(200)
+
+const firstGesture = await page.evaluate(() => (window).__playCalls.slice())
+
+// Gesture 2: a second drag should fire the triplet again (no sticky state).
+await page.evaluate(() => { (window).__playCalls.length = 0 })
+await page.evaluate(() => {
+  (window).__planet.setState({ drag: { axis: 'y', start: 0, slice: 1 } })
+})
+await page.waitForTimeout(200)
+await page.evaluate(() => {
+  (window).__planet.setState({ drag: null })
+})
+await page.waitForTimeout(200)
+
+const secondGesture = await page.evaluate(() => (window).__playCalls.slice())
+
+await browser.close()
+
+const starts1 = firstGesture.filter(k => k === 'axis_rotation_start').length
+const ends1   = firstGesture.filter(k => k === 'axis_rotation_end').length
+const starts2 = secondGesture.filter(k => k === 'axis_rotation_start').length
+const ends2   = secondGesture.filter(k => k === 'axis_rotation_end').length
+
+const startIdx1 = firstGesture.indexOf('axis_rotation_start')
+const endIdx1   = firstGesture.indexOf('axis_rotation_end')
+const orderOk   = startIdx1 !== -1 && endIdx1 !== -1 && startIdx1 < endIdx1
+
+console.log('\n=== axis rotation triplet observation ===\n')
+console.log('  gesture 1 play() calls:', JSON.stringify(firstGesture))
+console.log('  gesture 2 play() calls:', JSON.stringify(secondGesture))
+console.log()
+const ok1 = starts1 === 1
+const ok2 = ends1 === 1
+const ok3 = orderOk
+const ok4 = starts2 === 1 && ends2 === 1
+console.log(`  ${ok1 ? '✓' : '✗'} gesture 1: axis_rotation_start fired exactly once  (got ${starts1})`)
+console.log(`  ${ok2 ? '✓' : '✗'} gesture 1: axis_rotation_end   fired exactly once  (got ${ends1})`)
+console.log(`  ${ok3 ? '✓' : '✗'} gesture 1: start fires BEFORE end`)
+console.log(`  ${ok4 ? '✓' : '✗'} gesture 2: triplet repeats on a fresh drag         (start ${starts2}, end ${ends2})`)
+const allPass = ok1 && ok2 && ok3 && ok4
+console.log(`\n${allPass ? 'ALL PASS' : 'FAILURES PRESENT'}\n`)
+process.exit(allPass ? 0 : 1)


### PR DESCRIPTION
## Summary

- Adds two events — `axis_rotation_start` (rising edge) + `axis_rotation_end` (falling edge) — on top of the existing `axis_rotation` sustain loop.
- Loop key unchanged → existing `lvl_1/audio.json` overrides keep working.
- `synth:click` placeholders ship for both stingers; sound-design via the editor's SampleSwap.

Half the wiring was already there (`subscriptions.ts:23-40` does rising-edge detection for the #77 discoverability publish). Added the symmetric falling edge + two `audioBus.play()` calls.

### Ordering note (preserves #77)

The new `play('axis_rotation_start')` self-publishes via `lastTriggered`. It's called BEFORE the manual `publish('axis_rotation')` so the loop still wins auto-select on rotation start — the loop is the sustained thing the user tunes most often; stingers are quick swap-and-go.

## Test plan
- [x] `node tests/audio-rotation-triplet.mjs` — spies on `bus.play`, observes triplet fires once per gesture in order and repeats on a fresh drag (4/4 PASS)
- [x] `npx tsc --noEmit` clean
- [x] PR #77 auto-select intent verified — Inspector still lands on `axis_rotation` after a rotation starts (raw key inspection; the stale `audio-rotate-autoselect.mjs` test has pre-existing textContent rot from #76's inspector layout change, unrelated to this PR — separate cleanup)
- [ ] Sound-design the start/end one-shots via SampleSwap once merged (out of scope here)

## Out of scope
- Real sound design for the stingers (placeholders ship)
- Fixing the stale `audio-rotate-autoselect.mjs` textContent assertion (pre-existing rot from #76)