### PR TITLE
🧹 Audio: voice-graph cleanup batch (closes #69 #70 #71 #72)

### DIFF
--- a/src/world/audio/bus.ts
+++ b/src/world/audio/bus.ts
@@ -76,7 +76,6 @@ export interface LoopDef {
   key: string
   anchor: AnchorRef
   src: string
-  adsr?: ADSR
   // New shape: per-param bindings. Common keys:
   //   `vol`     — volume (sample loops via setVolume; synth 2D via synthGain;
   //               synth POSITIONAL via positional setVolume)
@@ -324,6 +323,17 @@ class AudioBus {
   // its 1/peak coefficient without re-scanning the buffer. Populated lazily
   // on buffer decode; absent for synth sources.
   private peakCoefficients = new Map<string, number>()
+  // #72 per-play graph allocation probe — Lokayata before optimizing
+  // the ADSR + voiceVol "extra GainNode" path. Public so devtools /
+  // window.__audioBus.probe can read counters during sustained
+  // trigger spam (e.g. footsteps while walking). reset() zeroes them.
+  // Cheap enough to ship in prod — three counter writes per play.
+  probe = {
+    plays: 0,            // total play() calls (excluding mute-gated returns)
+    gainNodesTotal: 0,   // sum of GainNodes allocated across all plays
+    doubleGainPlays: 0,  // plays where BOTH adsrGain + voiceGain were created
+    reset() { this.plays = 0; this.gainNodesTotal = 0; this.doubleGainPlays = 0 },
+  }
   // Active BufferSourceNodes per event key. Pushed on play(), removed on
   // 'ended'. Polyphony cap enforced by stopping voices[0] (oldest first).
   private activeEventSources = new Map<string, AudioBufferSourceNode[]>()
@@ -939,15 +949,15 @@ class AudioBus {
     void this.loadBuffer(def.src).then(buf => {
       if (!this.sfxGain) return
       // Polyphony gate — if at the cap, evict the oldest active voice
-      // BEFORE adding the new one. With ADSR present we trigger the
-      // release ramp on the old voice; without ADSR we stop immediately.
-      // 'ended' fires once src.stop completes either way, so the list
-      // self-prunes — we also shift here so the slot is synchronously free.
+      // BEFORE adding the new one. stopVoice handles the ADSR-vs-no-ADSR
+      // fork internally (fade or hard stop). 'ended' fires once src.stop
+      // completes either way, so the list self-prunes — we also shift
+      // here so the slot is synchronously free.
       if (def.polyphony != null && def.polyphony >= 1) {
         const list = this.activeEventSources.get(key) ?? []
         while (list.length >= def.polyphony) {
           const old = list.shift()
-          if (old) this.releaseAndStop(old)
+          if (old) this.stopVoice(old)
         }
         this.activeEventSources.set(key, list)
       }
@@ -974,24 +984,37 @@ class AudioBus {
       // adsrGain is only inserted when adsr is set (idle-default = no node,
       // identical to legacy path). voiceGain only inserted when voiceVol≠1
       // (matches prior behaviour to keep the unmodulated graph small).
+      // #72 probe: count this play + whether double-gain (adsr + voiceVol≠1)
+      // is hit. Cheap unconditional increments — see AudioBus.probe docs.
+      this.probe.plays++
+      if (def.adsr && voiceVol !== 1) this.probe.doubleGainPlays++
       const adsr = def.adsr
       let adsrGain: GainNode | null = null
       const now = ctx.currentTime
       if (adsr) {
         adsrGain = ctx.createGain()
-        const A = Math.max(0.001, (adsr.attack ?? 0) / 1000)
-        const D = Math.max(0, (adsr.decay ?? 0) / 1000)
+        this.probe.gainNodesTotal++
+        let A = Math.max(0.001, (adsr.attack ?? 0) / 1000)
+        let D = Math.max(0, (adsr.decay ?? 0) / 1000)
         const S = Math.max(0, Math.min(1, adsr.sustain ?? 1))
-        const R = Math.max(0.001, (adsr.release ?? 0) / 1000)
+        let R = Math.max(0.001, (adsr.release ?? 0) / 1000)
         const effDur = buf.duration / Math.max(0.0001, rate)
+        // #70 budget check. If the requested A+D+R exceeds the audible
+        // buffer length, scale all three proportionally to fit. Preserves
+        // attack/decay/release shape relative to one another instead of
+        // letting release tail past the BufferSource's natural end (where
+        // the gain ramp lands on a silent voice).
+        const total = A + D + R
+        if (total > effDur) {
+          const k = effDur / total
+          A *= k; D *= k; R *= k
+        }
         const g = adsrGain.gain
         g.setValueAtTime(0, now)
         g.linearRampToValueAtTime(1, now + A)
         g.linearRampToValueAtTime(S, now + A + D)
-        // Schedule release so the voice tails to silence right at
-        // effective end-of-buffer. If A+D leaves no room for R, push the
-        // release start to the latest moment that still fits.
-        const releaseStart = Math.max(now + A + D, now + Math.max(0, effDur - R))
+        // After squeeze: A+D+R ≤ effDur, so the release window always fits.
+        const releaseStart = now + Math.max(A + D, effDur - R)
         g.setValueAtTime(S, releaseStart)
         g.linearRampToValueAtTime(0, releaseStart + R)
         this.eventAdsrInfo.set(src, { gain: adsrGain, releaseSec: R })
@@ -1002,6 +1025,7 @@ class AudioBus {
         vg.gain.value = voiceVol
         vg.connect(this.sfxGain)
         dst = vg
+        this.probe.gainNodesTotal++
       }
       // Per-event EQ chain (#83). Built fresh per voice; spec values
       // resolved here (modulators evaluated at play time). Inserted
@@ -1079,11 +1103,13 @@ class AudioBus {
     return this.loadBuffer(src)
   }
 
-  /** Stop a per-play sample event with ADSR-aware fade. If the voice has
-   *  an ADSR gain, cancel pending automation, ramp the current value to
-   *  0 over `releaseSec`, then defer src.stop until the ramp completes.
-   *  Without ADSR, falls back to immediate stop (legacy behaviour). */
-  private releaseAndStop(src: AudioBufferSourceNode) {
+  /** #71 Stop a per-play sample event. When the voice has an ADSR
+   *  sidecar, fade out over `releaseSec` (cancel pending automation,
+   *  ramp current value → 0, defer src.stop until the ramp lands).
+   *  Without ADSR, calls src.stop() immediately — there's no envelope
+   *  to fade. Voice-stealing + auto-cleanup callers route through here
+   *  so both paths share the same "do the right thing per voice" logic. */
+  private stopVoice(src: AudioBufferSourceNode) {
     const info = this.eventAdsrInfo.get(src)
     const ctx = this.listener?.context
     if (!info || !ctx) {

--- a/tests/audio-normalize.mjs
+++ b/tests/audio-normalize.mjs
@@ -23,15 +23,23 @@ await page.goto(URL, { waitUntil: 'domcontentloaded' })
 await page.waitForFunction(() => !!(window).__audioBus, null, { timeout: 15000 })
 await page.waitForTimeout(600)
 
-// Kick the buffer load by calling previewLoop briefly — that path
-// resolves loadBuffer, which populates peakCoefficients.
+// Kick the buffer load via the public ensureBuffer wrapper, which calls
+// the same loadBuffer path that schedules computePeak. Crucially we
+// AWAIT the buffer promise inside evaluate — without that, headless
+// Chrome can keep the promise pending while waitForTimeout idles
+// (background XHR throttling). The await forces resolution before we
+// move on.
 await page.evaluate(async () => {
   const bus = (window).__audioBus
-  const stop = bus.previewLoop('theme_music', 5)
-  // give the buffer fetch + decode + peak scan time to land
-  await new Promise(r => setTimeout(r, 1500))
-  if (typeof stop === 'function') stop()
+  await bus.loadSampleBuffer('audio/theme.ogg').catch(() => {})
 })
+// Microtask drain — give the loadBuffer .then chain (which calls
+// computePeak) a tick to run after the awaited promise resolves.
+await page.waitForFunction(
+  () => (window).__audioBus?.peakCoefficients?.get('/audio/theme.ogg') != null,
+  null,
+  { timeout: 5_000 },
+).catch(() => { /* fall through — test assertion will report the miss */ })
 
 const probe = await page.evaluate(() => {
   const bus = (window).__audioBus
@@ -57,7 +65,7 @@ const probe = await page.evaluate(() => {
 
 // UI: render normalize toggle for the sample loop currently selected.
 await page.evaluate(() => (window).__lastTriggered?.getState?.().publish?.('theme_music'))
-await page.waitForTimeout(300)
+await page.waitForTimeout(800)
 const normalizeVisibleSampleLoop = await page.evaluate(() => {
   return [...document.querySelectorAll('label, span, div')]
     .some(el => /Normalize\s*\(0\s*dBFS\)/i.test(el.textContent || ''))
@@ -65,7 +73,7 @@ const normalizeVisibleSampleLoop = await page.evaluate(() => {
 
 // Hidden for synth loop.
 await page.evaluate(() => (window).__lastTriggered?.getState?.().publish?.('windmill_whoosh'))
-await page.waitForTimeout(300)
+await page.waitForTimeout(800)
 const normalizeHiddenSynthLoop = await page.evaluate(() => {
   return ![...document.querySelectorAll('label, span, div')]
     .some(el => /Normalize\s*\(0\s*dBFS\)/i.test(el.textContent || ''))

--- a/tests/audio-voice-graph-cleanup.mjs
+++ b/tests/audio-voice-graph-cleanup.mjs
@@ -1,0 +1,116 @@
+// Observe #69 + #71 + #72 wiring (no behavior change for users):
+//
+//  #69 LoopDef.adsr field stripped — verified via TS compile + registry
+//      sanity (no shipped loop carries an adsr value).
+//
+//  #71 releaseAndStop → stopVoice rename — bus.stopVoice present, old
+//      name absent.
+//
+//  #72 probe counter wired in play() — reset + 3 plays with varied
+//      adsr/voiceVol → counters tick the expected amounts.
+//
+//  #70 squeeze A+D+R proportionally is a pure math change inside play();
+//      not directly observable from outside. Verified by code review +
+//      composition (existing audio tests still pass).
+import { chromium } from 'playwright'
+
+const URL = 'http://localhost:7001/edit/levels/lvl_1/audio'
+
+const browser = await chromium.launch({ headless: true })
+const page = await browser.newPage()
+await page.goto(URL, { waitUntil: 'domcontentloaded' })
+await page.waitForFunction(() => !!(window).__audioBus, null, { timeout: 15000 })
+
+// Wait long enough for attachListener → sfxGain → all of init to land.
+// previewLoop's test was happy at 600ms; play() needs sfxGain so be safe.
+await page.waitForFunction(() => {
+  const b = (window).__audioBus
+  return !!b && !!b.sfxGain
+}, null, { timeout: 10_000 })
+
+const result = await page.evaluate(async () => {
+  const bus = (window).__audioBus
+
+  // ── #71 method rename ──
+  const hasStopVoice = typeof bus.stopVoice === 'function'
+  const hasOldName   = typeof bus.releaseAndStop === 'function'
+
+  // ── #69 verify no shipped loop has adsr field ──
+  // audioLive is bundled by the editor route; access via window stash.
+  // Fallback: rely on TS-time check + skip.
+  let noLoopHasAdsr = true
+  try {
+    const mod = await import('/src/world/audio/audioLive.ts')
+    noLoopHasAdsr = (mod.audioLive?.loops ?? []).every(l => !('adsr' in l) || l.adsr == null)
+  } catch { /* skip */ }
+
+  // ── #72 probe presence + reset ──
+  const hasProbe = !!bus.probe && typeof bus.probe.reset === 'function'
+
+  // Precache buffers so the .then(...) bodies (where probe lives) actually
+  // run within the test's wait budget. Without this, headless Chrome may
+  // still be fetching the .ogg files when we read the counter.
+  await Promise.all([
+    bus.loadSampleBuffer('audio/footstep_grass.ogg').catch(() => {}),
+    bus.loadSampleBuffer('audio/jump_grass.ogg').catch(() => {}),
+  ])
+
+  bus.probe.reset()
+  const probeAfterReset = { plays: bus.probe.plays, gainNodesTotal: bus.probe.gainNodesTotal, doubleGainPlays: bus.probe.doubleGainPlays }
+
+  // Fire 3 plays with varied combos. Footstep has no adsr in the shipped
+  // registry, jump same. So all three will be vanilla (no adsr branch).
+  // We still get gainNodesTotal increments from the voiceVol≠1 plays.
+  //
+  // Play 1: footstep, no override (voiceVol=1) → 0 gain nodes
+  bus.play('footstep')
+  // Play 2: footstep, vol=0.5 → 1 gain node (voiceGain)
+  bus.setEventOverride('footstep', { vol: 0.5 })
+  bus.play('footstep')
+  // Play 3: jump, vol=0.5 → 1 gain node (voiceGain)
+  bus.setEventOverride('jump', { vol: 0.5 })
+  bus.play('jump')
+
+  // 800ms is plenty after the buffers are cached — the .then resolves on
+  // the microtask queue right after the next tick.
+  await new Promise(r => setTimeout(r, 800))
+
+  const probeAfter = { plays: bus.probe.plays, gainNodesTotal: bus.probe.gainNodesTotal, doubleGainPlays: bus.probe.doubleGainPlays }
+
+  // Clean up overrides
+  bus.setEventOverride('footstep', { vol: undefined })
+  bus.setEventOverride('jump', { vol: undefined })
+
+  return { hasStopVoice, hasOldName, noLoopHasAdsr, hasProbe, probeAfterReset, probeAfter }
+})
+
+await browser.close()
+
+const ok1 = result.hasStopVoice                            // #71 new name
+const ok2 = !result.hasOldName                             // #71 old gone
+const ok3 = result.noLoopHasAdsr                           // #69 no shipped loop has adsr
+const ok4 = result.hasProbe                                // #72 probe exists
+const ok5 = result.probeAfterReset.plays === 0             // #72 reset zeroes
+const ok6 = result.probeAfter.plays >= 3                   // at least our 3 plays landed
+                                                            // (the App scene mounting in the iframe may
+                                                            //  fire its own ambient plays — we just
+                                                            //  need ours to be counted)
+const ok7 = result.probeAfter.gainNodesTotal >= 2          // ≥ 2 voiceGain allocations from our 2
+                                                            // vol-override plays (scene plays may add more)
+const ok8 = result.probeAfter.doubleGainPlays === 0        // no adsr in registry → no double-gain
+
+console.log('\n=== audio voice-graph cleanup observation ===\n')
+console.log('  probe after reset :', result.probeAfterReset)
+console.log('  probe after plays :', result.probeAfter)
+console.log()
+console.log(`  ${ok1 ? '✓' : '✗'} #71 bus.stopVoice() present`)
+console.log(`  ${ok2 ? '✓' : '✗'} #71 bus.releaseAndStop() removed  (got hasOld=${result.hasOldName})`)
+console.log(`  ${ok3 ? '✓' : '✗'} #69 no shipped loop carries adsr field  (got noLoopHasAdsr=${result.noLoopHasAdsr})`)
+console.log(`  ${ok4 ? '✓' : '✗'} #72 bus.probe object with reset() present`)
+console.log(`  ${ok5 ? '✓' : '✗'} #72 probe.reset() zeroes counters`)
+console.log(`  ${ok6 ? '✓' : '✗'} #72 probe.plays >= 3 (our 3 plays counted; scene may add more)  (got ${result.probeAfter.plays})`)
+console.log(`  ${ok7 ? '✓' : '✗'} #72 probe.gainNodesTotal >= 2 (our 2 vol-override plays counted)  (got ${result.probeAfter.gainNodesTotal})`)
+console.log(`  ${ok8 ? '✓' : '✗'} #72 probe.doubleGainPlays === 0 (no adsr in shipped registry)  (got ${result.probeAfter.doubleGainPlays})`)
+const allPass = ok1 && ok2 && ok3 && ok4 && ok5 && ok6 && ok7 && ok8
+console.log(`\n${allPass ? 'ALL PASS' : 'FAILURES PRESENT'}\n`)
+process.exit(allPass ? 0 : 1)


### PR DESCRIPTION
> **Stacked PR** — based on \`feat/audio-normalize\` (#92), which is itself based on \`feat/audio-loop-preview\` (#91). Merge #91 first, then #92, then this; each should auto-retarget once its base lands.

## Summary

Pure tech-debt sweep, no user-visible behavior change.

### #69 — \`LoopDef.adsr\` dead schema stripped
No runtime consumer. The editor doesn't expose ADSR for loops. Will be re-added with #60 audio crossfade if/when that lands.

### #70 — ADSR squeeze
\`A+D+R > effDur\` → scale all three by \`effDur/total\`. Previously the release ramp could be scheduled past the BufferSource's natural end, landing on a silent voice. Now the envelope shape is preserved and the release always fits.

### #71 — \`releaseAndStop\` → \`stopVoice\`
Old name implied a fade always happens; reality is it falls through to immediate \`src.stop()\` when no ADSR is present. New name + tightened doc.

### #72 — Probe instrumentation (no optimization yet)
Per the issue's P43 (Lokayata) note: **measure before optimizing**. Adds \`audioBus.probe\` with three counters (plays / gainNodesTotal / doubleGainPlays). Devtools-readable via \`window.__audioBus.probe\`. Run footstep spam, then \`bus.probe\` to see if the "extra GainNode under ADSR + voiceVol" cost actually shows up before folding voiceVol into \`adsrGain.sustain\`.

## Test plan
- [x] \`node tests/audio-voice-graph-cleanup.mjs\` — 8/8 PASS (probe counters, method rename, dead schema verified)
- [x] \`node tests/audio-normalize.mjs\` — PASS (also fixed an unrelated timing race in this test; see below)
- [x] \`node tests/audio-loop-preview.mjs\` — PASS
- [x] \`node tests/audio-rotation-triplet.mjs\` — PASS
- [x] \`node tests/audio-event-eq.mjs\` — PASS
- [x] \`npx tsc --noEmit\` clean

## Test-fix note
While running the composition sweep I uncovered an unrelated timing race in \`tests/audio-normalize.mjs\`: headless Chrome throttles unawaited background promises during \`waitForTimeout\`. Fix: \`await\` \`loadSampleBuffer\` inside the \`page.evaluate\` so the \`loadBuffer.then\` chain (which calls \`computePeak\`) settles before we poll for the cached peak coefficient. The previous test was a flake-on-cold-cache.

## Follow-up
- **#72 optimization** (fold \`voiceVol\` into \`adsrGain.sustain\`) is OUT OF SCOPE here. After this lands, run the probe during real walking gameplay; if \`doubleGainPlays\` is a meaningful fraction of total plays AND we see audio-thread latency issues, open a follow-up to do the fold.